### PR TITLE
Keep-alive

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 		"events"
 	],
 	"scripts": {
-		"preinstall": "npx only-allow pnpm",
 		"build": "webpack --env production",
 		"dev": "webpack --env development",
 		"test": "jest",

--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -14,6 +14,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+	jest.useRealTimers();
+
 	if (eventsource && eventsource.readyState !== 2) {
 		eventsource.close();
 	}
@@ -318,6 +320,24 @@ describe("retry", () => {
 				session.retry(8000);
 
 				expect(write).toHaveBeenCalledWith("retry:8000\n");
+
+				done();
+			});
+		});
+
+		eventsource = new EventSource(url);
+	});
+});
+
+describe("keep-alive", () => {
+	it("starts a keep-alive timer given no options", (done) => {
+		jest.useFakeTimers();
+
+		server.on("request", (req, res) => {
+			const session = new Session(req, res);
+
+			session.on("connected", () => {
+				expect(setInterval).toHaveBeenCalledTimes(1);
 
 				done();
 			});

--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -338,6 +338,45 @@ describe("keep-alive", () => {
 
 			session.on("connected", () => {
 				expect(setInterval).toHaveBeenCalledTimes(1);
+				expect(setInterval).toHaveBeenCalledWith(
+					expect.any(Function),
+					10000
+				);
+
+				done();
+			});
+		});
+
+		eventsource = new EventSource(url);
+	});
+
+	it("can set the keep-alive interval in options", (done) => {
+		jest.useFakeTimers();
+
+		server.on("request", (req, res) => {
+			const session = new Session(req, res, {keepAlive: 1000});
+
+			session.on("connected", () => {
+				expect(setInterval).toHaveBeenCalledWith(
+					expect.any(Function),
+					1000
+				);
+
+				done();
+			});
+		});
+
+		eventsource = new EventSource(url);
+	});
+
+	it("can disable the keep-alive mechanism in options", (done) => {
+		jest.useFakeTimers();
+
+		server.on("request", (req, res) => {
+			const session = new Session(req, res, {keepAlive: null});
+
+			session.on("connected", () => {
+				expect(setInterval).not.toHaveBeenCalled();
 
 				done();
 			});

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -45,6 +45,15 @@ export interface SessionOptions {
 	retry?: number | null;
 
 	/**
+	 * Time in milliseconds interval for the session to send a comment to keep the connection alive.
+	 *
+	 * Give as `null` to disable the connection keep-alive mechanism.
+	 *
+	 * Defaults to `10000` milliseconds (`10` seconds).
+	 */
+	keepAlive?: number | null;
+
+	/**
 	 * Status code to be sent to the client.
 	 *
 	 * Event stream requests can be redirected using HTTP 301 and 307 status codes.
@@ -98,6 +107,8 @@ class Session extends EventEmitter {
 	private sanitize: SanitizerFunction;
 	private trustClientEventId: boolean;
 	private initialRetry: number | null;
+	private keepAliveInterval: number | null;
+	private keepAliveTimer?: ReturnType<typeof setInterval>;
 	private statusCode: number;
 	private headers: OutgoingHttpHeaders;
 
@@ -118,6 +129,8 @@ class Session extends EventEmitter {
 		this.trustClientEventId = options.trustClientEventId ?? true;
 		this.initialRetry =
 			options.retry === null ? null : options.retry ?? 2000;
+		this.keepAliveInterval =
+			options.keepAlive === null ? null : options.keepAlive ?? 10000;
 		this.statusCode = options.statusCode ?? 200;
 		this.headers = options.headers ?? {};
 
@@ -146,12 +159,23 @@ class Session extends EventEmitter {
 			this.retry(this.initialRetry).dispatch();
 		}
 
+		if (this.keepAliveInterval !== null) {
+			this.keepAliveTimer = setInterval(
+				this.keepAlive,
+				this.keepAliveInterval
+			);
+		}
+
 		this.isConnected = true;
 
 		this.emit("connected");
 	};
 
 	private onDisconnected = () => {
+		if (this.keepAliveTimer) {
+			clearInterval(this.keepAliveTimer);
+		}
+
 		this.isConnected = false;
 
 		this.emit("disconnected");
@@ -168,6 +192,10 @@ class Session extends EventEmitter {
 		this.res.write(text);
 
 		return this;
+	};
+
+	private keepAlive = () => {
+		this.comment().dispatch();
 	};
 
 	/**


### PR DESCRIPTION
This PR adds a keep-alive mechanism that sends an empty comment in set intervals to prevent the connection from timing out.

In addition, it also:

* Removes the `preinstall` script from the root `package.json` as it prevented installing the example projects with `npm` instead of `pnpm`.