### PR TITLE
Polyfill support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Please consider starring the project [on GitHub ⭐](https://github.com/MatthewW
 * Add or override the response status code and headers.
 * Fine-grained control by either sending [individual fields](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#fields) of events or sending full events with simple helpers.
 * Pipe [streams](https://nodejs.org/api/stream.html#stream_readable_streams) directly from the server to the client as a stream of events.
+* Support for popular EventStream polyfills [`event-source-polyfill`](https://www.npmjs.com/package/event-source-polyfill) and [`eventsource-polyfill`](https://www.npmjs.com/package/eventsource-polyfill).
 
 # Installation
 

--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -884,6 +884,38 @@ describe("streaming", () => {
 describe("polyfill support", () => {
 	const lastEventId = "123456";
 
+	it("can retrieve the last event ID from 'event-source-polyfill' URL query", (done) => {
+		server.on("request", async (req, res) => {
+			const session = new Session(req, res);
+
+			await new Promise((resolve) => session.on("connected", resolve));
+
+			expect(session.lastId).toBe(lastEventId);
+
+			done();
+		});
+
+		eventsource = new EventSource(`${url}/?lastEventId=${lastEventId}`);
+	});
+
+	it("writes a preamble comment when indicated to by the 'event-source-polyfill' URL query", (done) => {
+		server.on("request", async (req, res) => {
+			const session = new Session(req, res);
+
+			const comment = jest.spyOn(session, "comment");
+			const dispatch = jest.spyOn(session, "dispatch");
+
+			await new Promise((resolve) => session.on("connected", resolve));
+
+			expect(comment).toHaveBeenLastCalledWith(" ".repeat(2049));
+			expect(dispatch).toHaveBeenCalled();
+
+			done();
+		});
+
+		eventsource = new EventSource(`${url}/?padding=true`);
+	});
+
 	it("can retrieve the last event ID from 'eventsource-polyfill' URL query", (done) => {
 		server.on("request", async (req, res) => {
 			const session = new Session(req, res);
@@ -900,17 +932,37 @@ describe("polyfill support", () => {
 		);
 	});
 
-	it("can retrieve the last event ID from 'event-source-polyfill' URL query", (done) => {
+	it("writes a preamble comment when indicated to by the 'eventsource-polyfill' URL query", (done) => {
 		server.on("request", async (req, res) => {
 			const session = new Session(req, res);
 
+			const comment = jest.spyOn(session, "comment");
+			const dispatch = jest.spyOn(session, "dispatch");
+
 			await new Promise((resolve) => session.on("connected", resolve));
 
-			expect(session.lastId).toBe(lastEventId);
+			expect(comment).toHaveBeenLastCalledWith(" ".repeat(2056));
+			expect(dispatch).toHaveBeenCalled();
 
 			done();
 		});
 
-		eventsource = new EventSource(`${url}/?lastEventId=${lastEventId}`);
+		eventsource = new EventSource(`${url}/?evs_preamble`);
+	});
+
+	it("does not write a preamble when not indicated to do so", (done) => {
+		server.on("request", async (req, res) => {
+			const session = new Session(req, res);
+
+			const comment = jest.spyOn(session, "comment");
+
+			await new Promise((resolve) => session.on("connected", resolve));
+
+			expect(comment).not.toHaveBeenCalled();
+
+			done();
+		});
+
+		eventsource = new EventSource(url);
 	});
 });

--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -880,3 +880,37 @@ describe("streaming", () => {
 		eventsource = new EventSource(url);
 	});
 });
+
+describe("polyfill support", () => {
+	const lastEventId = "123456";
+
+	it("can retrieve the last event ID from 'eventsource-polyfill' URL query", (done) => {
+		server.on("request", async (req, res) => {
+			const session = new Session(req, res);
+
+			await new Promise((resolve) => session.on("connected", resolve));
+
+			expect(session.lastId).toBe(lastEventId);
+
+			done();
+		});
+
+		eventsource = new EventSource(
+			`${url}/?evs_last_event_id=${lastEventId}`
+		);
+	});
+
+	it("can retrieve the last event ID from 'event-source-polyfill' URL query", (done) => {
+		server.on("request", async (req, res) => {
+			const session = new Session(req, res);
+
+			await new Promise((resolve) => session.on("connected", resolve));
+
+			expect(session.lastId).toBe(lastEventId);
+
+			done();
+		});
+
+		eventsource = new EventSource(`${url}/?lastEventId=${lastEventId}`);
+	});
+});

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -146,10 +146,10 @@ class Session extends EventEmitter {
 	}
 
 	private onConnected = () => {
-		if (this.trustClientEventId) {
-			const url = `http://${this.req.headers.host}${this.req.url}`;
-			const params = new URL(url).searchParams;
+		const url = `http://${this.req.headers.host}${this.req.url}`;
+		const params = new URL(url).searchParams;
 
+		if (this.trustClientEventId) {
 			const givenLastEventId =
 				this.req.headers["last-event-id"] ??
 				params.get("lastEventId") ??
@@ -168,6 +168,14 @@ class Session extends EventEmitter {
 		this.res.setHeader("Cache-Control", "no-cache, no-transform");
 		this.res.setHeader("Connection", "keep-alive");
 		this.res.flushHeaders();
+
+		if (params.has("padding")) {
+			this.comment(" ".repeat(2049)).dispatch();
+		}
+
+		if (params.has("evs_preamble")) {
+			this.comment(" ".repeat(2056)).dispatch();
+		}
 
 		if (this.initialRetry !== null) {
 			this.retry(this.initialRetry).dispatch();

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -147,7 +147,14 @@ class Session extends EventEmitter {
 
 	private onConnected = () => {
 		if (this.trustClientEventId) {
-			const givenLastEventId = this.req.headers["last-event-id"] ?? "";
+			const url = `http://${this.req.headers.host}${this.req.url}`;
+			const params = new URL(url).searchParams;
+
+			const givenLastEventId =
+				this.req.headers["last-event-id"] ??
+				params.get("lastEventId") ??
+				params.get("evs_last_event_id") ??
+				"";
 
 			this.lastId = givenLastEventId as string;
 		}


### PR DESCRIPTION
Resolves #22 and #21.

This PR adds support for the two most popular EventSource polyfills [`event-source-polyfill`](https://www.npmjs.com/package/event-source-polyfill) and [`eventsource-polyfill`](https://www.npmjs.com/package/eventsource-polyfill), extracting the last event ID from the optional query parameters and sending a 2KB preamble comment when requested by Internet Explorer-based clients.