### PR TITLE
Generator/Iterator Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added the [`Session#iterate`](./docs/api.md#sessioniterate-iterable-iterable--asynciterable-options--promisevoid) method that allows processing iterables and sending yielded values to the client as events.
+
+### Changed
+
+* Rename the [`Session#stream`](./docs/api.md#sessionstream-stream-readable-options--promiseboolean) `event` option to `eventName`.
+
 ## 0.5.0 - 2021-07-17
 
 ### Added

--- a/docs/api.md
+++ b/docs/api.md
@@ -102,7 +102,7 @@ This uses the [`push`](#session%23push%3A-(event%3A-string%2C-data%3A-any)-%3D>-
 
 |`options.`|Type|Default|Description|
 |-|-|-|-|
-|`event`|`string`|`"stream"`|Event name to use when dispatching a data event from the stream to the client.|
+|`eventName`|`string`|`"stream"`|Event name to use when dispatching a data event from the stream to the client.|
 
 #### `Session#iterate`: `(iterable: Iterable | AsyncIterable[, options]) => Promise<void>`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -98,9 +98,23 @@ Pipe readable stream data to the client.
 
 Each data emission by the stream emits a new event that is dispatched to the client.
 
+This uses the [`push`](#session%23push%3A-(event%3A-string%2C-data%3A-any)-%3D>-this-%7C-(data%3A-any)-%3D>-this) method under the hood.
+
 |`options.`|Type|Default|Description|
 |-|-|-|-|
 |`event`|`string`|`"stream"`|Event name to use when dispatching a data event from the stream to the client.|
+
+#### `Session#iterate`: `(iterable: Iterable | AsyncIterable[, options]) => Promise<void>`
+
+Iterate over an iterable and send yielded values as data to the client.
+
+Each yield emits a new event that is dispatched to the client.
+
+This uses the [`push`](#session%23push%3A-(event%3A-string%2C-data%3A-any)-%3D>-this-%7C-(data%3A-any)-%3D>-this) method under the hood.
+
+|`options.`|Type|Default|Description|
+|-|-|-|-|
+|`eventName`|`string`|`"iteration"`|Event name to use when dispatching a data event from the yielded value to the client.|
 
 ### `createSession`: `(ConstructorParameters<typeof Session>) => Promise<Session>`
 

--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -787,7 +787,7 @@ describe("streaming", () => {
 			const push = jest.spyOn(session, "push");
 
 			session.on("connected", async () => {
-				await session.stream(stream, {event: eventName});
+				await session.stream(stream, {eventName});
 
 				expect(push).toHaveBeenCalledWith(eventName, 1);
 			});

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -78,7 +78,7 @@ interface StreamOptions {
 	 *
 	 * Defaults to `"stream"`.
 	 */
-	event?: string;
+	eventName?: string;
 }
 
 interface IterateOptions {
@@ -358,7 +358,7 @@ class Session extends EventEmitter {
 		stream: Readable,
 		options: StreamOptions = {}
 	): Promise<boolean> => {
-		const {event = "stream"} = options;
+		const {eventName = "stream"} = options;
 
 		return new Promise<boolean>((resolve, reject) => {
 			stream.on("data", (chunk) => {
@@ -370,7 +370,7 @@ class Session extends EventEmitter {
 					data = chunk;
 				}
 
-				this.push(event, data);
+				this.push(eventName, data);
 			});
 
 			stream.once("end", () => resolve(true));


### PR DESCRIPTION
Inspired by [`fastify-sse-v2`](https://github.com/NodeFactoryIo/fastify-sse-v2), this PR adds support for processing iterables and sending yielded values back to the client as events.

In addition, it also renames the `Session#stream` `event` option to `eventName`.