### PR TITLE
Re-order session and channel event arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
+coverage/
 node_modules/
 .cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added the ability to the [`Session#push`](./docs/api.md#sessionpush-data-unknown-eventname-string-eventid-string--this) method to set a custom event ID.
+* Added a new Session `push` event that is emitted with the event data, name and ID when the [`Session#push`](./docs/api.md#sessionpush-data-unknown-eventname-string-eventid-string--this) method is called.
+
+### Changed
+
+* Re-order the arguments for the [`Session#push`](./docs/api.md#sessionpush-data-unknown-eventname-string-eventid-string--this) and [`Channel#broadcast`](#channelbroadcast-data-unknown-eventname-string-options-object--this) methods and their corresponding emitted event callbacks to always have the event data first and event name as an optional argument second.
+
 ## 0.6.0 - 2021-10-28
 
 ### Added

--- a/docs/api.md
+++ b/docs/api.md
@@ -83,7 +83,7 @@ Write a comment (an ignored field).
 
 This will not fire an event, but is often used to keep the connection alive.
 
-#### `Session#push`: `(event: string, data: any) => this` | `(data: any) => this`
+#### `Session#push`: `(data: unknown[, eventName: string]) => this`
 
 Create and dispatch an event with the given data all at once.
 
@@ -92,7 +92,7 @@ This is equivalent to calling `.event()`, `.id()`, `.data()` and `.dispatch()` i
 If no event name is given, the event name (type) is set to `"message"`.
 Note that this sets the event ID (and thus the [`lastId` property](#session%23lastid%3A-string)) to a string of eight random characters (`a-z0-9`).
 
-#### `Session#stream`: `(stream: Readable[, options]) => Promise<boolean>`
+#### `Session#stream`: `(stream: Readable[, options: object]) => Promise<boolean>`
 
 Pipe readable stream data to the client.
 
@@ -104,7 +104,7 @@ This uses the [`push`](#session%23push%3A-(event%3A-string%2C-data%3A-any)-%3D>-
 |-|-|-|-|
 |`eventName`|`string`|`"stream"`|Event name to use when dispatching a data event from the stream to the client.|
 
-#### `Session#iterate`: `(iterable: Iterable | AsyncIterable[, options]) => Promise<void>`
+#### `Session#iterate`: `(iterable: Iterable | AsyncIterable[, options: object]) => Promise<void>`
 
 Iterate over an iterable and send yielded values as data to the client.
 
@@ -160,7 +160,7 @@ Fires the `session-deregistered` event with the session as its first argument.
 
 If the session was disconnected the channel will also fire the `session-disconnected` event with the disconnected session as its first argument beforehand.
 
-#### `Channel#broadcast`: `(eventName: string, data: any[, options = {}]) => this`
+#### `Channel#broadcast`: `(data: unknown[, eventName: string[, options: object]]) => this`
 
 Broadcasts an event with the given name and data to every active session subscribed to the channel.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -83,14 +83,15 @@ Write a comment (an ignored field).
 
 This will not fire an event, but is often used to keep the connection alive.
 
-#### `Session#push`: `(data: unknown[, eventName: string]) => this`
+#### `Session#push`: `(data: unknown[, eventName: string[, eventId: string]]) => this`
 
 Create and dispatch an event with the given data all at once.
 
 This is equivalent to calling `.event()`, `.id()`, `.data()` and `.dispatch()` in that order.
 
 If no event name is given, the event name (type) is set to `"message"`.
-Note that this sets the event ID (and thus the [`lastId` property](#session%23lastid%3A-string)) to a string of eight random characters (`a-z0-9`).
+
+If no event ID is given, the event ID (and thus the [`lastId` property](#session%23lastid%3A-string)) is set to a string of eight random characters (matching `a-z0-9`).
 
 #### `Session#stream`: `(stream: Readable[, options: object]) => Promise<boolean>`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -93,6 +93,8 @@ If no event name is given, the event name (type) is set to `"message"`.
 
 If no event ID is given, the event ID (and thus the [`lastId` property](#session%23lastid%3A-string)) is set to a string of eight random characters (matching `a-z0-9`).
 
+Emits the `push` event with the given data, event name and event ID in that order.
+
 #### `Session#stream`: `(stream: Readable[, options: object]) => Promise<boolean>`
 
 Pipe readable stream data to the client.
@@ -167,7 +169,7 @@ Broadcasts an event with the given name and data to every active session subscri
 
 Under the hood this calls the [`push`](#session%23push%3A-(event%3A-string%2C-data%3A-any)-%3D>-this-%7C-(data%3A-any)-%3D>-this) method on every active session.
 
-Fires the `broadcast` event with the given event name and data in their respective order.
+Emits the `broadcast` event with the given data and event name in that order.
 
 |`options.`|Type|Default|Description|
 |-|-|-|-|

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -89,7 +89,7 @@ let count = 0;
 setInterval(() => {
 	count = count + 1;
 
-	ticker.broadcast("tick", count);
+	ticker.broadcast(count, "tick");
 }, 1000);
 ```
 
@@ -131,7 +131,7 @@ In our `ticker.ts` file, after you create your channel, add the following:
 
 ```javascript
 const broadcastSessionCount = () => {
-	ticker.broadcast("session-count", ticker.sessionCount);
+	ticker.broadcast(ticker.sessionCount, "session-count");
 };
 
 ticker
@@ -139,7 +139,7 @@ ticker
 	.on("session-deregistered", broadcastSessionCount);
 ```
 
-Here we create a function `broadcastSessionCount` that broadcasts an event with the name `session-count` and a value with the current total session count exposed to us under the [Channel `sessionCount` property](./api.md#channelsessioncount-number).
+Here we create a function `broadcastSessionCount` that broadcasts a value with the current total session count exposed to us under the [Channel `sessionCount` property](./api.md#channelsessioncount-number) with the event name `session-count`.
 
 We then listen on both the events `session-registered` and `session-deregistered` and set the `broadcastSessionCount` function as a callback for each. This way, every time a session joins or leaves the channel the count is re-broadcasted and updated for all of the existing sessions on the channel.
 
@@ -192,11 +192,11 @@ const ticker = createChannel();
 let count = 0;
 
 setInterval(() => {
-	ticker.broadcast("tick", count++);
+	ticker.broadcast(count++, "tick");
 }, 1000);
 
 const broadcastSessionCount = () => {
-	ticker.broadcast("session-count", ticker.sessionCount);
+	ticker.broadcast(ticker.sessionCount, "session-count");
 };
 
 ticker

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,7 @@ app.get(
 	"/sse",
 	/* Create the session */
 	(req, res) => {
-		res.sse.push("ping", "Hello world!");
+		res.sse.push("Hello world!", "ping");
 	}
 );
 ```

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -109,5 +109,3 @@ export class SseController {
   }
 }
 ```
-
-### 

--- a/examples/channels/channels/ticker.ts
+++ b/examples/channels/channels/ticker.ts
@@ -12,7 +12,7 @@ const ticker = createChannel();
 let count = 0;
 
 setInterval(() => {
-	ticker.broadcast("tick", count++);
+	ticker.broadcast(count++, "tick");
 }, 1000);
 
 /**
@@ -21,7 +21,7 @@ setInterval(() => {
  * is registered and deregistered.
  */
 const broadcastSessionCount = () => {
-	ticker.broadcast("session-count", ticker.sessionCount);
+	ticker.broadcast(ticker.sessionCount, "session-count");
 };
 
 ticker

--- a/examples/getting-started/server.ts
+++ b/examples/getting-started/server.ts
@@ -28,10 +28,10 @@ app.get(
 		next();
 	},
 	/**
-	 * Push an event named 'ping' to the client.
+	 * Push a message with the event name "push".
 	 */
 	(_, res) => {
-		res.sse.push("ping", "Hello world!");
+		res.sse.push("Hello world!", "push");
 	}
 );
 

--- a/examples/resource-monitor/channels/resource.ts
+++ b/examples/resource-monitor/channels/resource.ts
@@ -11,10 +11,10 @@ const broadcastSystemStats = async () => {
 	const {totalMemMb, freeMemMb} = await osu.mem.info();
 	const memoryUsage = (freeMemMb / totalMemMb) * 100;
 
-	resource.broadcast("system-stats", {
+	resource.broadcast({
 		cpuUsage,
 		memoryUsage,
-	});
+	}, "system-stats");
 
 	setTimeout(broadcastSystemStats, interval);
 };
@@ -27,10 +27,10 @@ const broadcastNetStats = async () => {
 		total: {inputMb, outputMb},
 	} = netStats as NetStatMetrics;
 
-	resource.broadcast("net-stats", {
+	resource.broadcast({
 		inputMb,
 		outputMb,
-	});
+	}, "net-stats");
 
 	setTimeout(broadcastNetStats, interval);
 };

--- a/examples/streams/server.ts
+++ b/examples/streams/server.ts
@@ -26,7 +26,7 @@ app.get("/sse", async (req, res) => {
 	/**
 	 * Push a final 'stream' event with the 'done' property.
 	 */
-	session.push("stream", {done});
+	session.push({done}, "stream");
 });
 
 const PORT = process.env.PORT ?? 8080;

--- a/src/Channel.test.ts
+++ b/src/Channel.test.ts
@@ -232,6 +232,28 @@ describe("broadcasting", () => {
 		eventsource = new EventSource(url);
 	});
 
+	it("calls push with a default event name if none is given", (done) => {
+		const channel = new Channel();
+
+		server.on("request", async (req, res) => {
+			const session = new Session(req, res);
+
+			const push = jest.spyOn(session, "push");
+
+			await waitForConnect(session);
+
+			channel.register(session);
+
+			channel.broadcast("data");
+
+			expect(push).toHaveBeenCalledWith("data", "message");
+
+			done();
+		});
+
+		eventsource = new EventSource(url);
+	});
+
 	it("emits a broadcast event with the same arguments", (done) => {
 		const channel = new Channel();
 

--- a/src/Channel.test.ts
+++ b/src/Channel.test.ts
@@ -208,7 +208,7 @@ describe("registering", () => {
 });
 
 describe("broadcasting", () => {
-	const args: [string, string] = ["custom", "data"];
+	const args: [string, string] = ["data", "eventName"];
 
 	it("calls push on all sessions with the same arguments", (done) => {
 		const channel = new Channel();

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -14,7 +14,7 @@ interface Events extends EventMap {
 	"session-registered": (session: Session) => void;
 	"session-deregistered": (session: Session) => void;
 	"session-disconnected": (session: Session) => void;
-	broadcast: (eventName: string, data: unknown) => void;
+	broadcast: (data: unknown, eventName: string) => void;
 }
 
 /**
@@ -84,23 +84,27 @@ class Channel extends TypedEmitter<Events> {
 	 *
 	 * Takes the same arguments as the `Session#push` method.
 	 */
-	broadcast(
-		eventName: string,
+	broadcast = (
 		data: unknown,
+		eventName?: string,
 		options: BroadcastOptions = {}
-	): this {
+	): this => {
+		if (!eventName) {
+			eventName = "message";
+		}
+
 		for (const session of this.sessions) {
 			if (options.filter && !options.filter(session)) {
 				continue;
 			}
 
-			session.push(eventName, data);
+			session.push(data, eventName);
 		}
 
-		this.emit("broadcast", eventName, data);
+		this.emit("broadcast", data, eventName);
 
 		return this;
-	}
+	};
 }
 
 export type {BroadcastOptions};

--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -763,6 +763,28 @@ describe("push", () => {
 
 		eventsource = new EventSource(url);
 	});
+
+	it("emits a push event with the same arguments", (done) => {
+		const args: [string, string, string] = ["data", "eventName", "eventId"];
+
+		const callback = jest.fn();
+
+		server.on("request", async (req, res) => {
+			const session = new Session(req, res);
+
+			await waitForConnect(session);
+
+			session.on("push", callback);
+
+			session.push(...args);
+
+			expect(callback).toHaveBeenCalledWith(...args);
+
+			done();
+		});
+
+		eventsource = new EventSource(url);
+	});
 });
 
 describe("streaming", () => {

--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -690,7 +690,7 @@ describe("push", () => {
 			const event = jest.spyOn(session, "event");
 
 			session.on("connected", () => {
-				session.push(eventName, dataToWrite);
+				session.push(dataToWrite, eventName);
 
 				expect(event).toHaveBeenCalledWith(eventName);
 
@@ -730,7 +730,7 @@ describe("push", () => {
 			session.on("connected", () => {
 				session.id(oldId);
 
-				session.push(eventName, dataToWrite);
+				session.push(dataToWrite, eventName);
 
 				const newId = session.lastId;
 
@@ -761,9 +761,9 @@ describe("streaming", () => {
 				await session.stream(stream);
 
 				expect(push).toHaveBeenCalledTimes(3);
-				expect(push).toHaveBeenNthCalledWith(1, "stream", 1);
-				expect(push).toHaveBeenNthCalledWith(2, "stream", 2);
-				expect(push).toHaveBeenNthCalledWith(3, "stream", 3);
+				expect(push).toHaveBeenNthCalledWith(1, 1, "stream");
+				expect(push).toHaveBeenNthCalledWith(2, 2, "stream");
+				expect(push).toHaveBeenNthCalledWith(3, 3, "stream");
 			});
 		});
 
@@ -794,7 +794,7 @@ describe("streaming", () => {
 			session.on("connected", async () => {
 				await session.stream(stream, {eventName});
 
-				expect(push).toHaveBeenCalledWith(eventName, 1);
+				expect(push).toHaveBeenCalledWith(1, eventName);
 			});
 		});
 
@@ -824,18 +824,18 @@ describe("streaming", () => {
 
 				expect(push).toHaveBeenNthCalledWith(
 					1,
-					"stream",
-					buffersToWrite[0].toString()
+					buffersToWrite[0].toString(),
+					"stream"
 				);
 				expect(push).toHaveBeenNthCalledWith(
 					2,
-					"stream",
-					buffersToWrite[1].toString()
+					buffersToWrite[1].toString(),
+					"stream"
 				);
 				expect(push).toHaveBeenNthCalledWith(
 					3,
-					"stream",
-					buffersToWrite[2].toString()
+					buffersToWrite[2].toString(),
+					"stream"
 				);
 
 				done();

--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -640,6 +640,7 @@ describe("comments", () => {
 describe("push", () => {
 	const dataToWrite = "testData";
 	const eventName = "testEvent";
+	const eventId = "123456";
 
 	it("calls all field writing methods", (done) => {
 		server.on("request", (req, res) => {
@@ -719,7 +720,25 @@ describe("push", () => {
 		eventsource = new EventSource(url);
 	});
 
-	it("generates and sets a new event ID", (done) => {
+	it("calls event ID with the given event ID", (done) => {
+		server.on("request", (req, res) => {
+			const session = new Session(req, res);
+
+			const id = jest.spyOn(session, "id");
+
+			session.on("connected", () => {
+				session.push(dataToWrite, eventName, eventId);
+
+				expect(id).toHaveBeenCalledWith(eventId);
+
+				done();
+			});
+		});
+
+		eventsource = new EventSource(url);
+	});
+
+	it("generates and sets a new event ID if no custom event ID is given", (done) => {
 		const oldId = "1234567890";
 
 		server.on("request", (req, res) => {

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -329,14 +329,16 @@ class Session<
 	 * @param eventOrData - Event name or data to write.
 	 * @param data - Data to write if `eventOrData` was an event name.
 	 */
-	push = (data: unknown, eventName?: string): this => {
+	push = (data: unknown, eventName?: string, eventId?: string): this => {
 		if (!eventName) {
 			eventName = "message";
 		}
 
-		const nextId = randomBytes(4).toString("hex");
+		if (!eventId) {
+			eventId = randomBytes(4).toString("hex");
+		}
 
-		this.event(eventName).id(nextId).data(data).dispatch();
+		this.event(eventName).id(eventId).data(data).dispatch();
 
 		return this;
 	};

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -93,6 +93,7 @@ interface IterateOptions {
 interface Events extends EventMap {
 	connected: () => void;
 	disconnected: () => void;
+	push: (data: unknown, eventName: string, eventId: string) => void;
 }
 
 /**
@@ -326,8 +327,8 @@ class Session<
 	 *
 	 * Note that this sets the event ID (and thus the `lastId` property) to a string of eight random characters (`a-z0-9`).
 	 *
-	 * @param eventOrData - Event name or data to write.
-	 * @param data - Data to write if `eventOrData` was an event name.
+	 * @param data - Data to write.
+	 * @param eventName - Event name to write.
 	 */
 	push = (data: unknown, eventName?: string, eventId?: string): this => {
 		if (!eventName) {
@@ -339,6 +340,8 @@ class Session<
 		}
 
 		this.event(eventName).id(eventId).data(data).dispatch();
+
+		this.emit("push", data, eventName, eventId);
 
 		return this;
 	};

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -163,8 +163,6 @@ class Session<
 		this.statusCode = options.statusCode ?? 200;
 		this.headers = options.headers ?? {};
 
-		this.push = this.push.bind(this);
-
 		this.req.on("close", this.onDisconnected);
 		setImmediate(this.onConnected);
 	}


### PR DESCRIPTION
This PR re-orders the `Session#push` and `Channel#broadcast` methods to always have the event data first and event name as an optional second argument. In addition, it also allows the user to set a custom event ID as an optional _third_ argument to the `Session#push` method and adds a new `push` event emitted by `Session` after the `Session#push` method is called.