### PR TITLE
Benchmarks setup

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -4,6 +4,8 @@ This section compares Better SSE with other server-sent events libraries for Nod
 
 Better SSE was designed to be the easiest and most powerful library for using server-sent events, better than all other existing solutions.
 
+## Features
+
 TL/DR: Better SSE supports all\* the features that other competing libraries do and much more. It is TypeScript-first (but obviously can be used with JavaScript), very well tested, easier to scale and much more flexible than others whilst *still* having a simpler programming interface for both simple and complex use cases.
 
 |Feature|[`better-sse`](https://www.npmjs.com/package/better-sse)|[`sse-channel`](https://www.npmjs.com/package/sse-channel)|[`sse`](https://www.npmjs.com/package/sse)|[`express-sse`](https://www.npmjs.com/package/express-sse)|[`server-sent-events`](https://www.npmjs.com/package/server-sent-events)|[`easy-server-sent-events`](https://www.npmjs.com/package/easy-server-sent-events)|[`sse-stream`](https://www.npmjs.com/package/sse-stream)|
@@ -23,3 +25,7 @@ TL/DR: Better SSE supports all\* the features that other competing libraries do 
 |Modify response status code|✔|❌|❌|✔|❌|❌|❌|
 
 \* Except event history maintenance... [Coming soon](https://github.com/MatthewWid/better-sse/issues/16)!
+
+## Performance
+
+You can run benchmarks yourself that compare Better SSE with other libraries in the [`benchmarks` project](../examples) in the `examples` directory.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,3 +14,4 @@ This directory showcases examples of using Better SSE.
 -   [Channels](./channels)
 -   [Streams](./streams)
 -   [System Resource Monitor](./resource-monitor)
+-   [Benchmarks](./benchmarks)

--- a/examples/benchmarks/benchmark.ts
+++ b/examples/benchmarks/benchmark.ts
@@ -1,0 +1,85 @@
+import express, {Express} from "express";
+import EventSource from "eventsource";
+import {Suite} from "benchmark";
+import {createSession, createChannel} from "better-sse";
+// @ts-ignore
+import SseChannel from "sse-channel";
+
+(async () => {
+	const name = "Push events with channels.";
+
+	const suite = new Suite(name, {
+		async: true,
+	});
+
+	suite.on("start", () => {
+		console.log(`Benchmarking "${name}".`);
+	});
+
+	suite.on("cycle", (event: Event) => {
+		console.log(String(event.target));
+	});
+
+	suite.on("complete", () => {
+		process.exit(0);
+	});
+
+	await Promise.all([
+		(async () => {
+			let count = 0;
+			let server: Express;
+			const port = 8000;
+			const channel = createChannel();
+
+			suite.add("better-sse", () => {
+				channel.broadcast(++count);
+			});
+
+			server = express();
+
+			server.get("/", async (req, res) => {
+				const session = await createSession(req, res);
+
+				channel.register(session);
+			});
+
+			await new Promise<void>((resolve) => server.listen(port, resolve));
+
+			new EventSource(`http://localhost:${port}`);
+
+			await new Promise((resolve) =>
+				channel.once("session-registered", resolve)
+			);
+		})(),
+		(async () => {
+			let count = 0;
+			let server: Express;
+			const port = 8010;
+			const channel = new SseChannel({jsonEncode: true});
+
+			suite.add("sse-channel", () => {
+				++count;
+
+				channel.send({
+					event: "message",
+					data: count,
+					id: count,
+				});
+			});
+
+			server = express();
+
+			server.get("/", (req, res) => {
+				channel.addClient(req, res);
+			});
+
+			await new Promise<void>((resolve) => server.listen(port, resolve));
+
+			new EventSource(`http://localhost:${port}`);
+
+			await new Promise((resolve) => channel.once("connect", resolve));
+		})(),
+	]);
+
+	suite.run();
+})();

--- a/examples/benchmarks/index.ts
+++ b/examples/benchmarks/index.ts
@@ -1,0 +1,1 @@
+import "./benchmark";

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -9,14 +9,17 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
+				"benchmark": "^2.1.4",
 				"better-sse": "^0.7.1",
 				"eventsource": "^1.1.0",
 				"express": "^4.17.1",
 				"node-os-utils": "^1.3.5",
+				"sse-channel": "^4.0.0",
 				"ts-node": "^10.4.0",
 				"ts-node-dev": "^1.1.8"
 			},
 			"devDependencies": {
+				"@types/benchmark": "^2.1.1",
 				"@types/express": "^4.17.11",
 				"@types/node": "^14.14.20",
 				"@types/node-os-utils": "^1.2.0"
@@ -90,6 +93,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
 			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+		},
+		"node_modules/@types/benchmark": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@types/benchmark/-/benchmark-2.1.1.tgz",
+			"integrity": "sha512-XmdNOarpSSxnb3DE2rRFOFsEyoqXLUL+7H8nSGS25vs+JS0018bd+cW5Ma9vdlkPmoTHSQ6e8EUFMFMxeE4l+g==",
+			"dev": true
 		},
 		"node_modules/@types/body-parser": {
 			"version": "1.19.1",
@@ -239,6 +248,15 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"node_modules/benchmark": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+			"integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+			"dependencies": {
+				"lodash": "^4.17.4",
+				"platform": "^1.3.3"
+			}
 		},
 		"node_modules/better-sse": {
 			"version": "0.7.1",
@@ -691,6 +709,11 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
 		"node_modules/make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -864,6 +887,11 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/platform": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+			"integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
+		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1027,6 +1055,11 @@
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
+		},
+		"node_modules/sse-channel": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/sse-channel/-/sse-channel-4.0.0.tgz",
+			"integrity": "sha512-I539Tc0gyDTQ2QCSg4v78Flxo/UbqR9x7JoyPcqaPtwo+qzeOw/fF+aPSbk0xTvBQAAAZk7Dlkc8K1bum5GUnw=="
 		},
 		"node_modules/statuses": {
 			"version": "1.5.0",
@@ -1313,6 +1346,12 @@
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
 			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
 		},
+		"@types/benchmark": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@types/benchmark/-/benchmark-2.1.1.tgz",
+			"integrity": "sha512-XmdNOarpSSxnb3DE2rRFOFsEyoqXLUL+7H8nSGS25vs+JS0018bd+cW5Ma9vdlkPmoTHSQ6e8EUFMFMxeE4l+g==",
+			"dev": true
+		},
 		"@types/body-parser": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
@@ -1446,6 +1485,15 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"benchmark": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+			"integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+			"requires": {
+				"lodash": "^4.17.4",
+				"platform": "^1.3.3"
+			}
 		},
 		"better-sse": {
 			"version": "0.7.1",
@@ -1795,6 +1843,11 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
 		"make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -1919,6 +1972,11 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+		},
+		"platform": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+			"integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
 		},
 		"proxy-addr": {
 			"version": "2.0.7",
@@ -2052,6 +2110,11 @@
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
 			}
+		},
+		"sse-channel": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/sse-channel/-/sse-channel-4.0.0.tgz",
+			"integrity": "sha512-I539Tc0gyDTQ2QCSg4v78Flxo/UbqR9x7JoyPcqaPtwo+qzeOw/fF+aPSbk0xTvBQAAAZk7Dlkc8K1bum5GUnw=="
 		},
 		"statuses": {
 			"version": "1.5.0",

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,14 +8,17 @@
 		"start": "ts-node $INIT_CWD/index.ts"
 	},
 	"dependencies": {
+		"benchmark": "^2.1.4",
 		"better-sse": "^0.7.1",
 		"eventsource": "^1.1.0",
 		"express": "^4.17.1",
 		"node-os-utils": "^1.3.5",
+		"sse-channel": "^4.0.0",
 		"ts-node": "^10.4.0",
 		"ts-node-dev": "^1.1.8"
 	},
 	"devDependencies": {
+		"@types/benchmark": "^2.1.1",
 		"@types/express": "^4.17.11",
 		"@types/node": "^14.14.20",
 		"@types/node-os-utils": "^1.2.0"


### PR DESCRIPTION
Related to #31.

This PR adds the groundwork for adding a benchmarking suite using [`Benchmark.js`](https://benchmarkjs.com/) and adds a singular simple benchmark comparing pushing an event using channels between `better-sse` and `sse-channel`.