### PR TITLE
Faster random event ID generation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -91,9 +91,9 @@ Create and dispatch an event with the given data all at once.
 
 This is equivalent to calling `.event()`, `.id()`, `.data()` and `.dispatch()` in that order.
 
-If no event name is given, the event name (type) is set to `"message"`.
+If no event name is given, the event name is set to `"message"`.
 
-If no event ID is given, the event ID (and thus the [`lastId` property](#session%23lastid%3A-string)) is set to a string of eight random characters (matching `a-z0-9`).
+If no event ID is given, the event ID (and thus the [`lastId` property](#session%23lastid%3A-string)) is set to a unique string generated using a cryptographic pseudorandom number generator.
 
 Emits the `push` event with the given data, event name and event ID in that order.
 
@@ -177,7 +177,7 @@ Broadcasts an event with the given name and data to every active session subscri
 
 Under the hood this calls the [`push`](#session%23push%3A-(event%3A-string%2C-data%3A-any)-%3D>-this-%7C-(data%3A-any)-%3D>-this) method on every active session.
 
-If no event name is given, the event name (type) is set to `"message"`.
+If no event name is given, the event name is set to `"message"`.
 
 Emits the `broadcast` event with the given data, event name and event ID in that order.
 

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -327,12 +327,13 @@ class Session<
 	 * Create and dispatch an event with the given data all at once.
 	 * This is equivalent to calling `.event()`, `.id()`, `.data()` and `.dispatch()` in that order.
 	 *
-	 * If no event name is given, the event name (type) is set to `"message"`.
+	 * If no event name is given, the event name is set to `"message"`.
 	 *
-	 * Note that this sets the event ID (and thus the `lastId` property) to a string of eight random characters (`a-z0-9`).
+	 * If no event ID is given, the event ID (and thus the `lastid` property) is set to a unique string generated using a cryptographic pseudorandom number generator.
 	 *
 	 * @param data - Data to write.
 	 * @param eventName - Event name to write.
+	 * @param eventId - Event ID to write.
 	 */
 	push = (data: unknown, eventName?: string, eventId?: string): this => {
 		if (!eventName) {

--- a/src/lib/generateId.test.ts
+++ b/src/lib/generateId.test.ts
@@ -1,12 +1,9 @@
 import {generateId} from "./generateId";
 
-it("generates a string with eight characters", () => {
-	expect(generateId()).toHaveLength(8);
-});
-
-it("generates an all-lowercase string", () => {
+it("returns a string", () => {
 	const id = generateId();
-	const lowercased = id.toLowerCase();
 
-	expect(id).toEqual(lowercased);
+	expect(typeof id).toBe("string");
+
+	console.log(id);
 });

--- a/src/lib/generateId.ts
+++ b/src/lib/generateId.ts
@@ -1,5 +1,11 @@
-import {randomBytes} from "crypto";
+import {randomUUID, randomBytes} from "crypto";
 
-const generateId = (): string => randomBytes(4).toString("hex");
+let generateId: () => string;
+
+if (randomUUID) {
+	generateId = () => randomUUID();
+} else {
+	generateId = () => randomBytes(4).toString("hex");
+}
 
 export {generateId};


### PR DESCRIPTION
Resolves #30.

This MR updates the internal event ID generation to use the new [`randomUUID`](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions) Node [`crypto`-library](https://nodejs.org/api/crypto.html) function and falls back to the old method of using [`randomBytes`](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) if it is not available.

This offers a significant performance boost when using the [`Session#push`](https://github.com/MatthewWid/better-sse/blob/master/docs/api.md#sessionpush-data-unknown-eventname-string-eventid-string--this) and [`Channel#broadcast`](https://github.com/MatthewWid/better-sse/blob/master/docs/api.md#sessionpush-data-unknown-eventname-string-eventid-string--this) methods.

Note that different to #30's recommendations, the event ID generation will now fallback to the old method, avoiding breaking backwards compatibility with Node 12, and as such does not require allowing the user to override the event ID generation function themselves.

---

Benchmarks before:

```
Benchmarking "Push events with channels.".
better-sse x 218,704 ops/sec ±10.83% (68 runs sampled)
sse-channel x 127,889 ops/sec ±21.00% (83 runs sampled)

Benchmarking "Push events with channels.".
better-sse x 242,813 ops/sec ±9.28% (75 runs sampled)
sse-channel x 116,833 ops/sec ±20.04% (76 runs sampled)

Benchmarking "Push events with channels.".
better-sse x 214,748 ops/sec ±10.64% (72 runs sampled)
sse-channel x 144,027 ops/sec ±1.30% (93 runs sampled)
```

Benchmarks after:

```
Benchmarking "Push events with channels.".
better-sse x 154,140 ops/sec ±4.59% (81 runs sampled)
sse-channel x 147,619 ops/sec ±12.56% (86 runs sampled)

Benchmarking "Push events with channels.".
better-sse x 151,673 ops/sec ±4.60% (80 runs sampled)
sse-channel x 156,103 ops/sec ±1.75% (89 runs sampled)

Benchmarking "Push events with channels.".
better-sse x 156,255 ops/sec ±4.56% (78 runs sampled)
sse-channel x 144,004 ops/sec ±12.88% (85 runs sampled)
```