### PR TITLE
Channel performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Update the [`Channel#broadcast`](#channelbroadcast-data-unknown-eventname-string-options-object--this) method to generate its own custom event ID and thus add it as an additional argument to its `broadcast` event callback function.
+* Update the [`Channel#broadcast`](./docs/api.md#channelbroadcast-data-unknown-eventname-string-options-object--this) method to generate its own custom event ID and thus add it as an additional argument to its `broadcast` event callback function.
 * Update the Channel `session-disconnected` event to be fired *before* the session is deregistered.
+* Update the [`Channel#register`](./docs/api.md#channelregister-session-session--this) and [`Channel#deregister`](./docs/api.md#channelderegister-session-session--this) to not do anything if the channel is already registered or deregistered, respectively.
 
 ## 0.7.1 - 2022-01-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Update the [`Channel#broadcast`](./docs/api.md#channelbroadcast-data-unknown-eventname-string-options-object--this) method to generate its own custom event ID and thus add it as an additional argument to its `broadcast` event callback function.
-* Update the Channel `session-disconnected` event to be fired *before* the session is deregistered.
 * Update the [`Channel#register`](./docs/api.md#channelregister-session-session--this) and [`Channel#deregister`](./docs/api.md#channelderegister-session-session--this) to not do anything if the channel is already registered or deregistered, respectively.
+
+### Fixed
+
+* Fixed the Channel `session-disconnected` being fired after instead of before the session is deregistered.
 
 ## 0.7.1 - 2022-01-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Update the [`Channel#broadcast`](#channelbroadcast-data-unknown-eventname-string-options-object--this) method to generate its own custom event ID and thus add it as an additional argument to its `broadcast` event callback function.
+* Update the Channel `session-disconnected` event to be fired *before* the session is deregistered.
 
 ## 0.7.1 - 2022-01-11
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -161,6 +161,8 @@ Note that a session must be [connected](#session%23isconnected%3A-boolean) befor
 
 Fires the `session-registered` event with the registered session as its first argument.
 
+If the session was already to begin with this method does nothing.
+
 #### `Channel#deregister`: `(session: Session) => this`
 
 Deregister a session so that it no longer receives events from this channel.
@@ -170,6 +172,8 @@ Note that sessions are automatically deregistered when they are disconnected.
 Fires the `session-deregistered` event with the session as its first argument.
 
 If the session was disconnected the channel will also fire the `session-disconnected` event with the disconnected session as its first argument beforehand.
+
+If the session was not registered to begin with this method does nothing.
 
 #### `Channel#broadcast`: `(data: unknown[, eventName: string[, options: object]]) => this`
 

--- a/src/Channel.test.ts
+++ b/src/Channel.test.ts
@@ -103,6 +103,29 @@ describe("registering", () => {
 		eventsource = new EventSource(url);
 	});
 
+	it("does not emit a registration event if the session is already registered", (done) => {
+		const channel = new Channel();
+
+		const callback = jest.fn();
+
+		channel.on("session-registered", callback);
+
+		server.on("request", async (req, res) => {
+			const session = new Session(req, res);
+
+			await waitForConnect(session);
+
+			channel.register(session);
+			channel.register(session);
+
+			expect(callback).toHaveBeenCalledTimes(1);
+
+			done();
+		});
+
+		eventsource = new EventSource(url);
+	});
+
 	it("removes a session from the active sessions after deregistering it", (done) => {
 		const channel = new Channel();
 
@@ -145,6 +168,28 @@ describe("registering", () => {
 
 			expect(deregisterCallback).toHaveBeenCalledWith(session);
 			expect(disconnectedCallback).not.toHaveBeenCalled();
+
+			done();
+		});
+
+		eventsource = new EventSource(url);
+	});
+
+	it("does not emit a deregistration event if the session was not registered to begin with", (done) => {
+		const channel = new Channel();
+
+		const callback = jest.fn();
+
+		channel.on("session-deregistered", callback);
+
+		server.on("request", async (req, res) => {
+			const session = new Session(req, res);
+
+			await waitForConnect(session);
+
+			channel.deregister(session);
+
+			expect(callback).not.toHaveBeenCalled();
 
 			done();
 		});

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -55,9 +55,15 @@ class Channel<
 	/**
 	 * Register a session so that it can start receiving events from this channel.
 	 *
+	 * If the session is already registered this method does nothing.
+	 *
 	 * @param session - Session to register.
 	 */
 	register(session: Session): this {
+		if (this.sessions.has(session)) {
+			return this;
+		}
+
 		if (!session.isConnected) {
 			throw new Error("Cannot register a non-active session.");
 		}
@@ -78,9 +84,15 @@ class Channel<
 	/**
 	 * Deregister a session so that it no longer receives events from this channel.
 	 *
+	 * If the session was not registered to begin with this method does nothing.
+	 *
 	 * @param session - Session to deregister.
 	 */
 	deregister(session: Session): this {
+		if (!this.sessions.has(session)) {
+			return this
+		}
+
 		this.sessions.delete(session);
 
 		this.emit("session-deregistered", session);

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -63,9 +63,9 @@ class Channel<
 		}
 
 		session.once("disconnected", () => {
-			this.deregister(session);
-
 			this.emit("session-disconnected", session);
+
+			this.deregister(session);
 		});
 
 		this.sessions.add(session);

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -32,7 +32,7 @@ class Channel<
 	 */
 	state = {} as State;
 
-	private sessions: Session[] = [];
+	private sessions = new Set<Session>();
 
 	constructor() {
 		super();
@@ -42,14 +42,14 @@ class Channel<
 	 * List of the currently active sessions subscribed to this channel.
 	 */
 	get activeSessions(): ReadonlyArray<Session> {
-		return this.sessions;
+		return Array.from(this.sessions);
 	}
 
 	/**
 	 * Number of sessions subscribed to this channel.
 	 */
 	get sessionCount(): number {
-		return this.sessions.length;
+		return this.sessions.size;
 	}
 
 	/**
@@ -68,7 +68,7 @@ class Channel<
 			this.emit("session-disconnected", session);
 		});
 
-		this.sessions.push(session);
+		this.sessions.add(session);
 
 		this.emit("session-registered", session);
 
@@ -81,7 +81,7 @@ class Channel<
 	 * @param session - Session to deregister.
 	 */
 	deregister(session: Session): this {
-		this.sessions = this.sessions.filter((current) => current !== session);
+		this.sessions.delete(session);
 
 		this.emit("session-deregistered", session);
 
@@ -105,7 +105,7 @@ class Channel<
 		const eventId = generateId();
 
 		const sessions = options.filter
-			? this.sessions.filter(options.filter)
+			? Array.from(this.sessions).filter(options.filter)
 			: this.sessions;
 
 		for (const session of sessions) {


### PR DESCRIPTION
This MR improves performance when using channels by implementing the underlying session list with a `Set` instead of an array.

In addition, it updates the `register` and `deregister` methods to short-circuit if the session is already registered or deregistered, respectively and updates the automatic session deregistration to fire the `session-disconnected` event _before_ the event is deregistered instead of _after_.