### PR TITLE
Additional cache response headers

### DIFF
--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -37,8 +37,11 @@ afterEach(async () => {
 describe("connection", () => {
 	const defaultHeaders: http.OutgoingHttpHeaders = {
 		"Content-Type": "text/event-stream",
-		"Cache-Control": "no-cache, no-transform",
+		"Cache-Control":
+			"private, no-cache, no-store, no-transform, must-revalidate, max-age=0",
 		Connection: "keep-alive",
+		Pragma: "no-cache",
+		"X-Accel-Buffering": "no",
 	};
 
 	it("constructs without errors when giving no options", (done) => {

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -217,8 +217,11 @@ class Session<
 
 		if (this.res instanceof Http1ServerResponse) {
 			headers["Content-Type"] = "text/event-stream";
-			headers["Cache-Control"] = "no-cache, no-transform";
+			headers["Cache-Control"] =
+				"private, no-cache, no-store, no-transform, must-revalidate, max-age=0";
 			headers["Connection"] = "keep-alive";
+			headers["Pragma"] = "no-cache";
+			headers["X-Accel-Buffering"] = "no";
 		} else {
 			headers["content-type"] = "text/event-stream";
 			headers["cache-control"] = "no-cache, no-transform";


### PR DESCRIPTION
Resolves #38.

This PR adds the additional response headers `Pragma` and `X-Accel-Buffering` and updates the `Cache-Control` header value, each to disable data transformation, proxy buffering and shared caching to completely disable response data caching.

This ensures that the data sent to the client is unmodified and fresh, as is intended for the correct operation of the event stream mechanism.