### PR TITLE
Session 'headers' option overwrites conflicting default headers

### DIFF
--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -255,6 +255,32 @@ describe("connection", () => {
 
 		eventsource = new EventSource(url);
 	});
+
+	it("can overwrite the default headers", (done) => {
+		const additionalHeaders = {
+			"X-Accel-Buffering": "yes",
+		};
+
+		server.on("request", (req, res) => {
+			const writeHead = jest.spyOn(res, "writeHead");
+
+			const session = new Session(req, res, {
+				headers: additionalHeaders,
+			});
+
+			session.on("connected", () => {
+				const sentHeaders = writeHead.mock.calls[0][1];
+
+				expect(sentHeaders).toMatchObject({
+					"X-Accel-Buffering": "yes",
+				});
+
+				done();
+			});
+		});
+
+		eventsource = new EventSource(url);
+	});
 });
 
 describe("dispatch", () => {
@@ -1078,7 +1104,10 @@ describe("polyfill support", () => {
 describe("http/2", () => {
 	const defaultHeaders: http2.OutgoingHttpHeaders = {
 		"content-type": "text/event-stream",
-		"cache-control": "no-cache, no-transform",
+		"cache-control":
+			"private, no-cache, no-store, no-transform, must-revalidate, max-age=0",
+		pragma: "no-cache",
+		"x-accel-buffering": "no",
 	};
 
 	let http2Client: http2.ClientHttp2Session;

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -223,10 +223,6 @@ class Session<
 
 		const headers: OutgoingHttpHeaders = {};
 
-		Object.entries(this.headers).forEach(([name, value]) => {
-			headers[name] = value ?? "";
-		});
-
 		if (this.res instanceof Http1ServerResponse) {
 			headers["Content-Type"] = "text/event-stream";
 			headers["Cache-Control"] =
@@ -236,7 +232,14 @@ class Session<
 			headers["X-Accel-Buffering"] = "no";
 		} else {
 			headers["content-type"] = "text/event-stream";
-			headers["cache-control"] = "no-cache, no-transform";
+			headers["cache-control"] =
+				"private, no-cache, no-store, no-transform, must-revalidate, max-age=0";
+			headers["pragma"] = "no-cache";
+			headers["x-accel-buffering"] = "no";
+		}
+
+		for (const [name, value] of Object.entries(this.headers)) {
+			headers[name] = value ?? "";
 		}
 
 		this.res.writeHead(this.statusCode, headers);


### PR DESCRIPTION
This PR updates the Session constructor options `header` field to overwrite conflicting default headers instead of being overwritten by them.