### PR TITLE
Make `State` generic parameter extend `Record<string, any>`

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -120,7 +120,7 @@ interface SessionEvents extends EventMap {
  * @param options - Options given to the session instance.
  */
 class Session<
-	State extends Record<string, unknown> = SessionState
+	State extends Record<string, any> = SessionState
 > extends TypedEmitter<SessionEvents> {
 	/**
 	 * The last ID sent to the client.


### PR DESCRIPTION
With `Record<string, unknown>`, you get a type error if you use an interface:

```ts
interface SessionState {
	id: string
}
const session = await createSession<SessionState>(req, res)
// Error:
// Type 'SessionState' does not satisfy the constraint 'Record<string, unknown>'.
//  Index signature for type 'string' is missing in type 'SessionState'.ts(2344)
```
