### PR TITLE
Allow passing different session "states" per channel

### DIFF
--- a/src/createChannel.ts
+++ b/src/createChannel.ts
@@ -1,7 +1,10 @@
 import {Channel} from "./Channel";
 
-const createChannel = <State extends Record<string, unknown>>(
+const createChannel = <
+	State extends Record<string, unknown>,
+	SessionState extends Record<string, unknown>
+>(
 	...args: ConstructorParameters<typeof Channel>
-): Channel<State> => new Channel<State>(...args);
+): Channel<State, SessionState> => new Channel<State, SessionState>(...args);
 
 export {createChannel};


### PR DESCRIPTION
When using different types of sessions, with different `state`s, it's useful to be able to specify the `state` type of sessions inside a channel (instead of overwriting / extending the interface).

This change allows to pass the session state type in addition to the channel state:

```ts
const channel = createChannel<any, { flag: boolean }>();
```