### PR TITLE
Session event batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.10.0 - 2023-09-28
+
 ### Added
 
+* Added the [`Session#batch`](./docs/api.md#sessionbatch-batcher-eventbuffer--buffer-eventbuffer--void--promisevoid--promisevoid) method that can be used to batch multiple events into a single transmission over the wire.
 * Added the [`EventBuffer`](./docs/api.md#eventbuffer) class that can be used to write raw spec-compliant SSE fields into a text buffer that can be sent directly over the wire.
 
 ### Deprecated

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,6 +95,17 @@ This uses the [`push`](#session%23push%3A-(event%3A-string%2C-data%3A-any)-%3D>-
 |-|-|-|-|
 |`eventName`|`string`|`"iteration"`|Event name to use when dispatching a data event from the yielded value to the client.|
 
+#### `Session#batch`: `(batcher: EventBuffer | ((buffer: EventBuffer) => void | Promise<void>)) => Promise<void>`
+
+Batch and send multiple events at once.
+
+If given an [`EventBuffer`](#eventbuffer) instance, its contents will be sent to the client.
+
+If given a callback, it will be passed an instance of [`EventBuffer`](#eventbuffer) which uses the same serializer and sanitizer as the session.  
+Once its execution completes - or once it resolves if it returns a promise - the contents of the passed [`EventBuffer`](#eventbuffer) will be sent to the client.
+
+Returns a promise that resolves once all data from the event buffer has been successfully sent to the client.
+
 #### `Session#event`: `(type: string) => this`
 
 **⚠ DEPRECATED:** This method is deprecated. [See here](https://github.com/MatthewWid/better-sse/issues/52). 
@@ -227,8 +238,6 @@ Takes the [same arguments as the Channel class constructor](#new-channel()).
 ### `EventBuffer`
 
 An `EventBuffer` allows you to write [raw spec-compliant SSE fields](https://html.spec.whatwg.org/multipage/server-sent-events.html#processField) into a text buffer that can be sent directly over the wire.
-
-This is made available for users with more advanced use-cases who need to create an event text stream from scratch themselves. Most users will not need to access this directly and can use the simplified helper methods provided by the [`Session`](#session) class instead.
 
 #### `new EventBuffer([options = {}])`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "better-sse",
 	"description": "Dead simple, dependency-less, spec-compliant server-side events implementation for Node, written in TypeScript.",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"main": "./build/index.js",
 	"types": "./build/index.d.ts",
 	"license": "MIT",

--- a/src/EventBuffer.ts
+++ b/src/EventBuffer.ts
@@ -22,8 +22,6 @@ interface EventBufferOptions {
 
 /**
  * An `EventBuffer` allows you to write raw spec-compliant SSE fields into a text buffer that can be sent directly over the wire.
- *
- * This is made available for users with more advanced use-cases who need to create an event text stream from scratch themselves. Most users will not need to access this directly and can use the simplified helper methods provided by the `Session` class instead.
  */
 class EventBuffer {
 	private buffer = "";
@@ -121,7 +119,7 @@ class EventBuffer {
 	};
 
 	/**
-	 * Create, write and dispatch an event with the given data to the client all at once.
+	 * Create, write and dispatch an event with the given data all at once.
 	 *
 	 * This is equivalent to calling the methods `event`, `id`, `data` and `dispatch` in that order.
 	 *
@@ -151,7 +149,7 @@ class EventBuffer {
 	 * If no event name is given in the `options` object, the event name is set to `"stream"`.
 	 *
 	 * @param stream - Readable stream to consume data from.
-	 * @param options - Options to alter how the stream is flushed to the client.
+	 * @param options - Event name to use for each event created.
 	 *
 	 * @returns A promise that resolves or rejects based on the success of the stream write finishing.
 	 */


### PR DESCRIPTION
Resolves #42.

This PR adds the ability to batch and send multiple events at once to a session using [event buffers](https://github.com/MatthewWid/better-sse/blob/master/docs/api.md#eventbuffer).

---

Example usage:

```typescript
session.batch((batched) => {
  for (let i = 0; i < 100; ++i) {
    batched.push(`Event no. ${i}`);
  }
});
```

---

Using the exact same helpers as you would with `Session` (`push`, `iterate` and `stream`) you can batch together many events and then send all them in a single transmission.

This is more significantly more performant and uses less network bandwidth overall, and is a necessary precursor to implementing the [event history API](#16).

See [the API documentation](https://github.com/MatthewWid/better-sse/blob/master/docs/api.md#sessionbatch-batcher-eventbuffer--buffer-eventbuffer--void--promisevoid--promisevoid) for more.