### PR TITLE
Add option to pass eventId on broadcast

### DIFF
--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -12,6 +12,7 @@ interface BroadcastOptions<
 	 * Called with each session and should return `true` to allow the event to be sent and otherwise return `false` to prevent the session from receiving the event.
 	 */
 	filter?: (session: Session<SessionState>) => boolean;
+	eventId?: string;
 }
 
 interface ChannelEvents<
@@ -130,7 +131,7 @@ class Channel<
 		eventName = "message",
 		options: BroadcastOptions<SessionState> = {}
 	): this => {
-		const eventId = generateId();
+		const eventId = options.eventId ?? generateId();
 
 		const sessions = options.filter
 			? this.activeSessions.filter(options.filter)


### PR DESCRIPTION
Was wondering why it's not possible to pass your own eventId using the broadcast function of a channel.
Instead of the generated random UUID you can now pass your own with the use of the options parameter.