### PR TITLE
Allow passing initial session and channel state in constructor

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,7 @@ Note that creating a new session will immediately send the initial status code a
 |`keepAlive`|`number` \| `null`|`10000`|Time in milliseconds interval for the session to send a comment to keep the connection alive.<br><br>Give as `null` to disable the keep-alive mechanism.|
 |`statusCode`|`number`|`200`|Status code to be sent to the client.<br><br>Event stream requests can be redirected using HTTP 301 and 307 status codes. Make sure to set `Location` header when using these status codes (301/307) using the `headers` property.<br><br>A client can be asked to stop reconnecting by send a 204 status code.|
 |`headers`|`object`|`{}`|Additional headers to be sent along with the response.|
+|`state`|`object`|`{}`|Initial custom state for the session.<br><br>Accessed via the [`state`](#sessionstate-state) property.<br><br>When using TypeScript, providing the initial state structure allows the type of the `state` property to be automatically inferred.|
 
 #### `Session#lastId`: `string`
 
@@ -59,6 +60,8 @@ Indicates whether the session and underlying connection is open or not.
 Custom state for this session.
 
 Use this object to safely store information related to the session and user.
+
+You may set an initial value for this property using the `state` property in the [constructor `options` object](#new-sessionstate--defaultsessionstatereq-incomingmessage--http2serverrequest-res-serverresponse--http2serverresponse-options--), allowing its type to be automatically inferred.
 
 Use [module augmentation and declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) to safely add new properties to the `DefaultSessionState` interface.
 
@@ -174,13 +177,23 @@ A `Channel` is used to broadcast events to many sessions at once.
 You may use the second generic argument `SessionState` to enforce that only sessions
 with the same state type may be registered with this channel.
 
-#### `new Channel<State, SessionState>()`
+#### `new Channel<State, SessionState>([options = {}])`
+
+`options` is an object with the following properties:
+
+|Property|Type|Default|Description|
+|-|-|-|-|
+|`state`|`object`|`{}`|Initial custom state for the channel.<br><br>Accessed via the [`state`](#channelstate-state) property.<br><br>When using TypeScript, providing the initial state structure allows the type of the `state` property to be automatically inferred.|
 
 #### `Channel#state`: `State`
 
 Custom state for this channel.
 
 Use this object to safely store information related to the channel.
+
+You may set an initial value for this property using the `state` property in the [constructor `options` object](#new-channelstate-sessionstate), allowing its type to be automatically inferred.
+
+Use [module augmentation and declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) to safely add new properties to the `DefaultChannelState` interface.
 
 #### `Channel#activeSessions`: `ReadonlyArray<Session>`
 

--- a/examples/create-keys.ts
+++ b/examples/create-keys.ts
@@ -1,0 +1,10 @@
+import {createCertificate} from "pem";
+
+createCertificate({days: 1, selfSigned: true}, (error, result) => {
+	if (error) {
+		console.error(error);
+		return;
+	}
+
+	console.log(result);
+});

--- a/examples/getting-started/pubsub.ts
+++ b/examples/getting-started/pubsub.ts
@@ -1,0 +1,42 @@
+import {Session, Channel, createChannel} from "better-sse";
+
+class PubSub {
+	private events = new Map<string, Channel>();
+
+	subscribe(session: Session, event: string): void {
+		if (!this.events.has(event)) {
+			const newChannel = createChannel();
+
+			this.events.set(event, newChannel);
+
+			// Clean up channel if no more subscribers
+			newChannel.on("session-deregistered", () => {
+				if (newChannel.sessionCount === 0) {
+					this.events.delete(event);
+				}
+			});
+		}
+
+		const channel = this.events.get(event) as Channel;
+
+		channel.register(session);
+	}
+
+	unsubscribe(session: Session, event: string): void {
+		const channel = this.events.get(event);
+
+		if (channel) {
+			channel.deregister(session);
+		}
+	}
+
+	publish(data: unknown, event: string): void {
+		const channel = this.events.get(event);
+
+		if (channel) {
+			channel.broadcast(data, event);
+		}
+	}
+}
+
+export {PubSub};

--- a/src/Channel.test.ts
+++ b/src/Channel.test.ts
@@ -45,6 +45,16 @@ describe("construction", () => {
 	});
 });
 
+describe("state", () => {
+	const givenState = {id: "123"};
+
+	it("can set the initial state in options", () => {
+		const channel = new Channel({state: givenState});
+
+		expect(channel.state.id).toBe(givenState.id);
+	});
+});
+
 describe("registering", () => {
 	it("can register and store an active session", () =>
 		new Promise<void>((done) => {

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -3,6 +3,17 @@ import {TypedEmitter, EventMap} from "./lib/TypedEmitter";
 import {generateId} from "./lib/generateId";
 import {SseError} from "./lib/SseError";
 
+interface ChannelOptions<
+	State extends Record<string, unknown> = DefaultChannelState
+> {
+	/**
+	 * Custom state for this channel.
+	 *
+	 * Use this object to safely store information related to the channel.
+	 */
+	state?: State;
+}
+
 interface BroadcastOptions<
 	SessionState extends Record<string, unknown> = DefaultSessionState
 > {
@@ -49,12 +60,14 @@ class Channel<
 	 *
 	 * Use this object to safely store information related to the channel.
 	 */
-	state = {} as State;
+	state: State;
 
 	private sessions = new Set<Session<SessionState>>();
 
-	constructor() {
+	constructor(options: ChannelOptions<State> = {}) {
 		super();
+
+		this.state = options.state ?? ({} as State);
 	}
 
 	/**

--- a/src/Session.test.ts
+++ b/src/Session.test.ts
@@ -265,6 +265,25 @@ describe("connection", () => {
 		}));
 });
 
+describe("state", () => {
+	const givenState = {id: "123"};
+
+	it("can set the initial state in options", () =>
+		new Promise<void>((done) => {
+			server.on("request", async (req, res) => {
+				const session = new Session(req, res, {state: givenState});
+
+				await waitForConnect(session);
+
+				expect(session.state.id).toBe(givenState.id);
+
+				done();
+			});
+
+			eventsource = new EventSource(url);
+		}));
+});
+
 describe("retry", () => {
 	it("writes an initial retry field by default", () =>
 		new Promise<void>((done) => {


### PR DESCRIPTION
This PR adds the ability to initialize the value of the `state` property in the `Session` and `Channel` constructor `options` objects.

While enabling the user to construct and set the session/channel state in a single statement, this also allows the TypeScript compiler to automatically infer the state type from the given state value, rather than it having to explicitly defined by passing a type/interface to the `State` generic.

---

Before:

```typescript
interface SessionState {
  id: string;
}

const session = await createSession<SessionState>(req, res);

session.state.id = "123";

session.state.id = 456; // Error!
```

After:

```typescript
const session = await createSession(req, res, {
  state: {
    id: "123"
  }
});

session.state.id = 456; // Error!
```