### PR TITLE
Fix default state being `unknown` when creating sessions and channels with factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fixed default state type when creating sessions and channels with `createSession` and `createChannel` being set to `unknown` instead of `DefaultSessionState` and `DefaultChannelState`, respectively.
+
 ## 0.13.0 - 2024-08-23
 
 ### Added

--- a/src/createChannel.ts
+++ b/src/createChannel.ts
@@ -1,6 +1,10 @@
-import {Channel} from "./Channel";
+import {Channel, DefaultChannelState} from "./Channel";
+import {DefaultSessionState} from "./Session";
 
-const createChannel = <State, SessionState>(
+const createChannel = <
+	State = DefaultChannelState,
+	SessionState = DefaultSessionState,
+>(
 	...args: ConstructorParameters<typeof Channel<State, SessionState>>
 ): Channel<State, SessionState> => new Channel<State, SessionState>(...args);
 

--- a/src/createSession.ts
+++ b/src/createSession.ts
@@ -1,9 +1,9 @@
-import {Session} from "./Session";
+import {Session, DefaultSessionState} from "./Session";
 
 /**
  * Create a new session and return the session instance once it has connected.
  */
-const createSession = <State>(
+const createSession = <State = DefaultSessionState>(
 	...args: ConstructorParameters<typeof Session<State>>
 ): Promise<Session<State>> =>
 	new Promise((resolve) => {


### PR DESCRIPTION
This PR fixes an issue where, when creating a session or channel with `createSession` or `createChannel`, if no explicit type is given to the `State` generic it defaults to `unknown` rather than `DefaultSessionState` or `DefaultChannelState`, respectively.