### PR TITLE
Support passing ReadableStream to stream methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the `Session#getRequest` and `Session#getResponse` methods to retrieve the Fetch API `Request` and `Response` objects, respectively.
 * Added the `createResponse` utility function to create a `Session` instance and immediately return its associated `Response` object.
 * Added type overloads for each combination of arguments to `createSession` and the `Session` constructor.
+* Added support for passing a `ReadableStream` from the Web Streams API to `Session#stream` and `EventBuffer#stream`.
 
 ### Changed
 

--- a/src/lib/createPushFromStream.test.ts
+++ b/src/lib/createPushFromStream.test.ts
@@ -1,77 +1,154 @@
-import {Readable} from "node:stream";
-import {type Mock, beforeEach, expect, it, vi} from "vitest";
+import {Readable as NodeReadableStream} from "node:stream";
+import {type Mock, beforeEach, describe, expect, it, vi} from "vitest";
 import {createPushFromStream} from "./createPushFromStream";
 
 const data = [1, 2, 3];
-let push: Mock<[unknown, string]>;
+let push: Mock<Parameters<typeof createPushFromStream>[0]>;
 let func: ReturnType<typeof createPushFromStream>;
-let stream: Readable;
 
 beforeEach(() => {
 	push = vi.fn();
 	func = createPushFromStream(push);
-	stream = Readable.from(data);
 });
 
-it("pipes each and every stream data emission as an event", async () => {
-	await func(stream);
+describe("Node stream.Readable", () => {
+	let stream: NodeReadableStream;
 
-	expect(push).toHaveBeenCalledTimes(3);
-	expect(push).toHaveBeenNthCalledWith(1, 1, "stream");
-	expect(push).toHaveBeenNthCalledWith(2, 2, "stream");
-	expect(push).toHaveBeenNthCalledWith(3, 3, "stream");
-});
-
-it("can override the event type in options", async () => {
-	const eventName = "newEventName";
-
-	await func(stream, {eventName});
-
-	expect(push).toHaveBeenCalledWith(1, eventName);
-});
-
-it("serializes buffers as strings", async () => {
-	const buffersToWrite = [
-		Buffer.from([1, 2, 3]),
-		Buffer.from([4, 5, 6]),
-		Buffer.from([7, 8, 9]),
-	];
-
-	const stream = Readable.from(buffersToWrite);
-
-	await func(stream);
-
-	expect(push).toHaveBeenNthCalledWith(
-		1,
-		buffersToWrite[0].toString(),
-		"stream"
-	);
-	expect(push).toHaveBeenNthCalledWith(
-		2,
-		buffersToWrite[1].toString(),
-		"stream"
-	);
-	expect(push).toHaveBeenNthCalledWith(
-		3,
-		buffersToWrite[2].toString(),
-		"stream"
-	);
-});
-
-it("resolves with 'true' when stream finishes and is successful", async () => {
-	const response = await func(stream);
-
-	expect(response).toBeTruthy();
-});
-
-it("throws with the same error that the stream errors with", async () => {
-	const error = new Error();
-
-	const stream = new Readable({
-		read() {
-			this.destroy(error);
-		},
+	beforeEach(() => {
+		stream = NodeReadableStream.from(data);
 	});
 
-	await expect(func(stream)).rejects.toThrow(error);
+	it("pipes each and every stream data emission as an event", async () => {
+		await func(stream);
+
+		expect(push).toHaveBeenCalledTimes(3);
+		expect(push).toHaveBeenNthCalledWith(1, 1, "stream");
+		expect(push).toHaveBeenNthCalledWith(2, 2, "stream");
+		expect(push).toHaveBeenNthCalledWith(3, 3, "stream");
+	});
+
+	it("can override the event type in options", async () => {
+		const eventName = "newEventName";
+
+		await func(stream, {eventName});
+
+		expect(push).toHaveBeenCalledWith(1, eventName);
+	});
+
+	it("serializes buffers as strings", async () => {
+		const buffersToWrite = [
+			Buffer.from([1, 2, 3]),
+			Buffer.from([4, 5, 6]),
+			Buffer.from([7, 8, 9]),
+		];
+
+		stream = NodeReadableStream.from(buffersToWrite);
+
+		await func(stream);
+
+		expect(push).toHaveBeenNthCalledWith(
+			1,
+			buffersToWrite[0].toString(),
+			"stream"
+		);
+		expect(push).toHaveBeenNthCalledWith(
+			2,
+			buffersToWrite[1].toString(),
+			"stream"
+		);
+		expect(push).toHaveBeenNthCalledWith(
+			3,
+			buffersToWrite[2].toString(),
+			"stream"
+		);
+	});
+
+	it("resolves with 'true' when stream finishes and is successful", async () => {
+		const response = await func(stream);
+
+		expect(response).toBeTruthy();
+	});
+
+	it("throws with the same error that the stream errors with", async () => {
+		const error = new Error();
+
+		stream = new NodeReadableStream({
+			read() {
+				this.destroy(error);
+			},
+		});
+
+		await expect(func(stream)).rejects.toThrow(error);
+	});
+});
+
+describe("Web ReadableStream", () => {
+	let stream: ReadableStream;
+
+	beforeEach(() => {
+		stream = ReadableStream.from(data);
+	});
+
+	it("pipes each and every stream data emission as an event", async () => {
+		await func(stream);
+
+		expect(push).toHaveBeenCalledTimes(3);
+		expect(push).toHaveBeenNthCalledWith(1, 1, "stream");
+		expect(push).toHaveBeenNthCalledWith(2, 2, "stream");
+		expect(push).toHaveBeenNthCalledWith(3, 3, "stream");
+	});
+
+	it("can override the event type in options", async () => {
+		const eventName = "newEventName";
+
+		await func(stream, {eventName});
+
+		expect(push).toHaveBeenCalledWith(1, eventName);
+	});
+
+	it("serializes buffers as strings", async () => {
+		const buffersToWrite = [
+			Buffer.from([1, 2, 3]),
+			Buffer.from([4, 5, 6]),
+			Buffer.from([7, 8, 9]),
+		];
+
+		stream = ReadableStream.from(buffersToWrite);
+
+		await func(stream);
+
+		expect(push).toHaveBeenNthCalledWith(
+			1,
+			buffersToWrite[0].toString(),
+			"stream"
+		);
+		expect(push).toHaveBeenNthCalledWith(
+			2,
+			buffersToWrite[1].toString(),
+			"stream"
+		);
+		expect(push).toHaveBeenNthCalledWith(
+			3,
+			buffersToWrite[2].toString(),
+			"stream"
+		);
+	});
+
+	it("resolves with 'true' when stream finishes and is successful", async () => {
+		const response = await func(stream);
+
+		expect(response).toBeTruthy();
+	});
+
+	it("throws with the same error that the stream errors with", async () => {
+		const error = new Error();
+
+		stream = new ReadableStream({
+			pull(controller) {
+				controller.error(error);
+			},
+		});
+
+		await expect(func(stream)).rejects.toThrow(error);
+	});
 });


### PR DESCRIPTION
This PR updates the `Session#stream` and `EventBuffer#stream` methods to be able to take in a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) from the [Web Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API).