### PR TITLE
Fetch API Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.15.0 - 2025-05-22
+
 ### Added
 
 * Added support for the `Session` constructor to be able to take in a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) (and optionally a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)) object from the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).

--- a/docs/src/content/docs/guides/batching.mdx
+++ b/docs/src/content/docs/guides/batching.mdx
@@ -14,7 +14,7 @@ While SSE is already performant and bandwidth-efficient, sending many events at 
 
 ## Using the `batch` method
 
-To batch and send multiple events at a time, simply invoke [`Session#batch`](/better-sse/reference/api#sessionbatch-batcher-eventbuffer--buffer-eventbuffer--void--promisevoid--promisevoid) method and pass a callback that takes an [event buffer](/better-sse/reference/api#eventbuffer) as its first argument:
+To batch and send multiple events at a time, simply invoke the [`Session#batch`](/better-sse/reference/api#sessionbatch-batcher-eventbuffer--buffer-eventbuffer--void--promisevoid--promisevoid) method and pass a callback that takes an [event buffer](/better-sse/reference/api#eventbuffer) as its first argument:
 
 ```typescript title="server.ts"
 await session.batch(async (buffer) => {
@@ -22,12 +22,12 @@ await session.batch(async (buffer) => {
 });
 ```
 
-You can use the same helper methods as you would with the session itself ([`push`](/better-sse/reference/api#sessionpush-data-unknown-eventname-string-eventid-string--this), [`stream`](/better-sse/reference/api#sessionstream-stream-readable-options-object--promiseboolean) and [`iterate`](/better-sse/reference/api#sessioniterate-iterable-iterable--asynciterable-options-object--promisevoid)) with the buffer.
+You can use the same helper methods as you would with the session itself ([`push`](/better-sse/reference/api#sessionpush-data-unknown-eventname-string-eventid-string--this), [`stream`](/better-sse/reference/api#sessionstream-stream-streamreadable--readablestream-options-object--promiseboolean) and [`iterate`](/better-sse/reference/api#sessioniterate-iterable-iterable--asynciterable-options-object--promisevoid)) with the buffer.
 
 When the callback finishes execution - or resolves if it returns a promise - every event created with the buffer will be sent to the client all at once in a single network transmission.
 
 <Aside>
-    Events created with event buffers do not use the underlying `Session#push` method and will *not* trigger the `push` event to be emitted on the session instance.
+    Events created with event buffers do **not** use the underlying `Session#push` method and will *not* trigger the `push` event to be emitted on the session instance.
 </Aside>
 
 ## Create your own event buffer
@@ -35,27 +35,29 @@ When the callback finishes execution - or resolves if it returns a promise - eve
 You can also create an event buffer outside of the context of a single session and then write its contents to one or many sessions later on. To do so, create an event buffer and then pass it directly to the `batch` method:
 
 ```typescript title="server.ts"
-import { createEventBuffer } from "better-sse";
+import { createEventBuffer } from "better-sse"
 
-const buffer = createEventBuffer();
+const buffer = createEventBuffer()
 
-buffer.push("One");
-buffer.push("Two");
-buffer.push("Three");
+buffer.push("One")
+buffer.push("Two")
+buffer.push("Three")
 
-session.batch(buffer);
+await session.batch(buffer)
 ```
 
-Or send the buffer contents to every session on a [channel](/better-sse/guides/channels), for example:
+Or send the buffer contents to every session on a channel, for example:
 
 ```typescript title="server.ts"
-channel.activeSessions.forEach((session) => {
-    session.batch(buffer);
-});
+await Promise.all(
+    channel.activeSessions.map((session) =>
+        session.batch(buffer)
+    )
+)
 ```
 
-<Aside title="Sanitize your data" type="caution" >
-    Keep in mind that, unless you explicitly pass them via [the `sanitizer` and/or `serializer` constructor arguments](/better-sse/reference/api/#new-eventbufferoptions-), event buffers do *not* have the same data serializer and sanitizer functions as the session being called.
+<Aside title="Sanitize your data" type="caution">
+    Keep in mind that, unless you explicitly pass them via [the `sanitizer` and/or `serializer` constructor arguments](/better-sse/reference/api/#new-eventbufferoptions-eventbufferoptions), event buffers do **not** have the same data serializer and sanitizer functions as the session being called.
 
     This does not apply when you use the [`Session#batch`](/better-sse/reference/api/#sessionbatch-batcher-eventbuffer--buffer-eventbuffer--void--promisevoid--promisevoid) method as it will automatically copy the serializer and sanitizer from the session to the event buffer instance it creates for you.
 </Aside>
@@ -65,9 +67,9 @@ channel.activeSessions.forEach((session) => {
 For users needing more fine-grained control over the exact data being sent over the wire, event buffers also allow you to write [raw spec-compliant SSE fields](https://html.spec.whatwg.org/multipage/server-sent-events.html#processField) into a string that can be read and sent over the wire as-is.
 
 ```typescript title="server.ts"
-import { createEventBuffer } from "better-sse";
+import { createEventBuffer } from "better-sse"
 
-const buffer = createEventBuffer();
+const buffer = createEventBuffer()
 
 buffer
   .retry(2400)
@@ -76,11 +78,11 @@ buffer
   .data("one")
   .data("two")
   .data("three")
-  .dispatch();
+  .dispatch()
 
-res.write(buffer.read());
+res.write(buffer.read())
 
-buffer.clear();
+buffer.clear()
 ```
 
 This is an advanced use-case. For most users, you should still stick with using [`Session`](/better-sse/reference/api#sessionstate) by default.

--- a/docs/src/content/docs/guides/channels.mdx
+++ b/docs/src/content/docs/guides/channels.mdx
@@ -30,84 +30,115 @@ We are going to be making a channel that does two things:
 
 Let's start off from where the Getting Started guide finished as a base:
 
-```typescript title="server.ts"
-import { createSession } from "better-sse";
+<Tabs syncKey="framework">
+    <TabItem label="Express">
+        ```typescript title="server.ts"
+        app.get("/sse", async (req, res) => {
+            const session = await createSession(req, res)
+            session.push("Hello world!", "ping")
+        })
+        ```
+    </TabItem>
+    <TabItem label="Hono">
+        ```typescript title="server.ts"
+        app.get("/sse", (c) =>
+            createResponse(c.req.raw, (session) => {
+                session.push("Hello world!", "ping")
+            })
+        )
+        ```
+    </TabItem>
+</Tabs>
 
-app.get("/sse", async (req, res) => {
-	const session = await createSession(req, res);
-
-	session.push("Hello world!", "ping");
-);
-```
-
-Right now we have a simple mechanism where a client connects and receives an event with the data `"Hello world!"`.
+Right now we have a simple mechanism where a client connects and receives a single event named `ping` with the data `"Hello world!"`.
 
 This is nice, but what if we want to say hi to everyone at once? Or in a more real-world example, send live updates about real-time events in our system to select groups of our users? This is where we can use channels.
 
-To make a channel, you simply need to call the exported `createChannel` factory function.
+To make a channel, you simply need to call the exported `createChannel` function.
 
-Let's create a channel called *ticker* in a new file and export it:
+Let's create a channel called "ticker" in a new file and export it:
 
 ```typescript title="channels/ticker.ts"
-import { createChannel } from "better-sse";
+import { createChannel } from "better-sse"
 
-const ticker = createChannel();
+const ticker = createChannel()
 
-export { ticker };
+export { ticker }
 ```
 
 Then import the channel to where your route handler is located and *register* the session so that it can start receiving events:
 
-```typescript title="server.ts" ins={2, 9} del={7}
-import { createSession } from "better-sse";
-import { ticker } from "./channels/ticker";
+<Tabs syncKey="framework">
+    <TabItem label="Express">
+        ```typescript title="server.ts" ins={2, 7} del={6}
+        import { createSession } from "better-sse"
+        import { ticker } from "./channels/ticker"
 
-app.get("/sse", async (req, res) => {
-	const session = await createSession(req, res);
+        app.get("/sse", async (req, res) => {
+            const session = await createSession(req, res)
+            session.push("Hello world!", "ping")
+            ticker.register(session)
+        )
+        ```
+    </TabItem>
+    <TabItem label="Hono">
+        ```typescript title="server.ts" ins={2, 7} del={6}
+        import { createSession } from "better-sse"
+        import { ticker } from "./channels/ticker"
 
-	session.push("Hello world!", "ping");
+        app.get("/sse", (c) => 
+            createResponse(c.req.raw, (session) => {
+                session.push("Hello world!", "ping")
+                ticker.register(session)
+            })
+        )
+        ```
+    </TabItem>
+</Tabs>
 
-	ticker.register(session);
-);
-```
-
-New sessions will now be subscribed to your channel and will start receiving its events!
+New sessions will now be subscribed to events broadcast on your channel!
 
 Channels are powerful in that you can register your session to listen on many channels at once or none at all. This makes it dynamically configurable based on what channels your client may or may not be authorized to receive events from and allows you to have a lot of flexibility in your implementation.
 
 ### Make a synchronized counter
 
-Now that you have a channel and your sessions are registered with it, lets actually make it do something.
+Now that you have a channel and new sessions are being registered with it, let's actually make it *do* something.
 
 We are going to have a number that increments by one (1) every second and synchronize it across all of our connected clients in real time.
 
-Right after your create your channel, add the following:
+First let's add a value `count` to our channel *state*:
 
-```typescript title="channels/ticker.ts"
-let count = 0;
-
-setInterval(() => {
-	count += 1;
-	ticker.broadcast(count, "tick");
-}, 1000);
+```typescript title="channels/ticker.ts" ins={2-4}
+const ticker = createChannel({
+    state: {
+        count: 0,
+    }
+})
 ```
 
-Here we have a variable `count` that gets incremented by `1` every 1000ms (one second).
+This could be a separate variable declared with `let`, but using the [`state`](/better-sse/reference/api/#channelstate-state) property is a nice way to group data related to specific channels and sessions.
 
-We then broadcast the value of `count` on the `ticker` channel every interval under the event name `tick` which will be received by all of our registered sessions.
+Next, add a timer that increments `count` by one (1) and then broadcasts its new value under the event name `tick`:
 
-Back on our client-side let's write some code that updates a text field on the page with the received value:
+```typescript title="channels/ticker.ts"
+setInterval(() => {
+    ticker.state.count += 1
+    ticker.broadcast(ticker.state.count, "tick")
+}, 1000)
+```
+
+Back on the front-end let's write some code that updates a text field on the page with the received value:
 
 ```typescript
 // public/client.js
-const countElement = document.createElement("pre");
-document.body.appendChild(countElement);
+const countElement = document.createElement("pre")
+document.body.appendChild(countElement)
 
-const eventSource = new EventSource("/sse");
+const eventSource = new EventSource("/sse")
 
 eventSource.addEventListener("tick", ({ data }) => {
-	countElement.innerText = `The clock has ticked! The count is now ${data}.`;
-});
+	countElement.innerText = `The clock has ticked! The count is now ${data}.`
+})
 ```
 
 In this snippet the following is happening:
@@ -116,42 +147,42 @@ In this snippet the following is happening:
 2. We create an [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) to listen to events from our server.
 3. We listen for the `tick` event and, when received, set the text in `countElement` to display the received value, corresponding to the `count` variable on the server.
 
-Open it up in your browser (you can [run the pre-made example project](https://github.com/MatthewWid/better-sse/tree/master/examples/channels) if you haven't been following along) and you will now see your ticking counter being updated in real time!
+Open it up in your browser (you can [run the pre-made `channels` example project](https://github.com/MatthewWid/better-sse/tree/master/examples/channels) if you haven't been following along) and you will now see your ticking counter being updated in real time!
 
 You can open the same page in multiple tabs at once and notice that the value is kept in sync across them all. Easy!
 
 ### Track online users
 
-Let's add some more functionality to our `ticker` channel. This time we want to keep our users in the know about how many other users are on the site at the same time as them. No one wants to feel lonely!
+Let's add some more functionality to our `ticker` channel. This time we want to keep our users in the know about how many other users are on the site at the same time as them. Nobody wants to feel lonely!
 
-Channels [emit events](https://nodejs.org/api/events.html#events_class_eventemitter) when certain things happen such as sessions being registered, deregistered and being disconnected. Let's listen on these events to broadcast the total number of connected sessions at any given time.
+Channels [emit events](https://nodejs.org/api/events.html#events_class_eventemitter) when certain things happen such as sessions being registered, deregistered and disconnected. Let's listen on these events to broadcast the total number of connected sessions at any given time.
 
 Add the following code after where you create the channel:
 
-```typescript title="channel/ticker.ts"
+```typescript title="channels/ticker.ts"
 const broadcastSessionCount = () => {
-	ticker.broadcast(ticker.sessionCount, "session-count");
-};
+	ticker.broadcast(ticker.sessionCount, "session-count")
+}
 
 ticker
 	.on("session-registered", broadcastSessionCount)
-	.on("session-deregistered", broadcastSessionCount);
+	.on("session-deregistered", broadcastSessionCount)
 ```
 
-Here we create a function `broadcastSessionCount` that broadcasts a value with the current total session count exposed to us under the [Channel `sessionCount` property](/better-sse/reference/api/#channelsessioncount-number) with the event name `session-count`.
+Here we create a function `broadcastSessionCount` that broadcasts a value with the current total session count exposed to us under the [`sessionCount` property](/better-sse/reference/api/#channelsessioncount-number) with the event name `session-count`.
 
 We then listen on both the events `session-registered` and `session-deregistered` and set the `broadcastSessionCount` function as a callback for each. This way, every time a session joins or leaves the channel the count is re-broadcasted and updated for all of the existing sessions on the channel.
 
-Back on our client lets add another listener for our new event that displays the session count in another text field:
+Back on our client lets add another listener for our new event that displays the session count in a different text field:
 
 ```typescript
 // public/client.js
-const sessionsElement = document.createElement("pre");
-document.body.appendChild(sessionsElement);
+const sessionsElement = document.createElement("pre")
+document.body.appendChild(sessionsElement)
 
 eventSource.addEventListener("session-count", ({ data }) => {
-	sessionsElement.innerText = `There are ${data} person(s) here right now!`;
-});
+	sessionsElement.innerText = `There are ${data} person(s) here right now!`
+})
 ```
 
 We do a similar thing to our previous example:
@@ -164,62 +195,91 @@ Once again open the page in your browser ([or run the example project](https://g
 <details>
 	<summary>See the finished code</summary>
 
-```typescript title="server.ts"
-import express from "express";
-import { createSession } from "better-sse";
-import { ticker } from "./channels/ticker";
+<Tabs syncKey="framework">
+    <TabItem label="Express">
+        ```typescript title="server.ts"
+        import express from "express"
+        import { createSession } from "better-sse"
+        import { ticker } from "./channels/ticker"
 
-const app = express();
+        const app = express()
 
-app.use(express.static("./public"));
+        app.use(express.static("./public"))
 
-app.get("/sse", async (req, res) => {
-	const session = await createSession(req, res);
+        app.get("/sse", async (req, res) => {
+            const session = await createSession(req, res)
+            ticker.register(session)
+        })
 
-	ticker.register(session);
-});
+        app.listen(8080)
+        ```
+    </TabItem>
+    <TabItem label="Hono">
+        ```typescript title="server.ts"
+        import { Hono } from "hono"
+        import { serve } from "@hono/node-server"
+        import { serveStatic } from "@hono/node-server/serve-static"
+        import { createResponse } from "better-sse"
+        import { ticker } from "./channels/ticker"
 
-app.listen(8080);
-```
+        const app = new Hono()
+
+        app.use("*", serveStatic({ root: "./public" }))
+
+        app.get("/sse", (c) =>
+            createResponse(c.req.raw, (session) => {
+                ticker.register(session)
+            })
+        )
+
+        serve({
+            fetch: app.fetch,
+            port: 8080,
+        })
+        ```
+    </TabItem>
+</Tabs>
 
 ```typescript title="channels/ticker.ts"
-import { createChannel } from "better-sse";
+import { createChannel } from "better-sse"
 
-const ticker = createChannel();
-
-let count = 0;
+const ticker = createChannel({
+    state: {
+        count: 0,
+    },
+})
 
 setInterval(() => {
-	ticker.broadcast(count++, "tick");
-}, 1000);
+	ticker.broadcast(ticket.state.count++, "tick")
+}, 1000)
 
 const broadcastSessionCount = () => {
-	ticker.broadcast(ticker.sessionCount, "session-count");
-};
+	ticker.broadcast(ticker.sessionCount, "session-count")
+}
 
 ticker
 	.on("session-registered", broadcastSessionCount)
-	.on("session-deregistered", broadcastSessionCount);
+	.on("session-deregistered", broadcastSessionCount)
 
-export { ticker };
+export { ticker }
 ```
 
 ```typescript
 // public/client.js
-const eventSource = new EventSource("/sse");
+const eventSource = new EventSource("/sse")
 
-const sessionsElement = document.createElement("pre");
-document.body.appendChild(sessionsElement);
+const sessionsElement = document.createElement("pre")
+document.body.appendChild(sessionsElement)
 
 eventSource.addEventListener("tick", ({ data }) => {
-	countElement.innerText = `The clock has ticked! The count is now ${data}.`;
-});
+	countElement.innerText = `The clock has ticked! The count is now ${data}.`
+})
 
-const countElement = document.createElement("pre");
-document.body.appendChild(countElement);
+const countElement = document.createElement("pre")
+document.body.appendChild(countElement)
 
 eventSource.addEventListener("session-count", ({ data }) => {
-	sessionsElement.innerText = `There are ${data} person(s) here right now!`;
-});
+	sessionsElement.innerText = `There are ${data} person(s) here right now!`
+})
 ```
 </details>

--- a/docs/src/content/docs/guides/getting-started.mdx
+++ b/docs/src/content/docs/guides/getting-started.mdx
@@ -17,9 +17,10 @@ Compared to WebSockets it has comparable performance and bandwidth usage, especi
 * [Comparison: Server-sent Events vs WebSockets vs Polling](https://medium.com/dailyjs/a-comparison-between-websockets-server-sent-events-and-polling-7a27c98cb1e3)
 * [WHATWG standards section for server-sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html)
 * [MDN guide to server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
+* [Can I use... Server-sent events](https://caniuse.com/eventsource)
 
 <Aside title="Use your own framework">
-    This guide uses the [Express web-server](https://expressjs.com/) in its code examples, but Better SSE works with any web-server framework that uses the underlying [Node HTTP module](https://nodejs.org/api/http.html). For example usage with other popular frameworks, see the [Recipes](/better-sse/reference/recipes/) section.
+    These guides use [Express](https://expressjs.com/) and [Hono](https://hono.dev/) in their code examples, but Better SSE works with any web-server framework that uses the [Node HTTP module](https://nodejs.org/api/http.html) or the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). For example usage with other popular frameworks see the [Recipes](/better-sse/reference/recipes/) section.
 </Aside>
 
 ### How does it work?
@@ -39,7 +40,7 @@ The technology can be used for things such as live notifications, news tickers, 
 
 ### Install
 
-Better SSE is shipped [as a package on npm](https://www.npmjs.com/package/better-sse). You can install it with any Node package manager.
+Better SSE is shipped [as a package on npm](https://www.npmjs.com/package/better-sse). You can install it with any package manager.
 
 <Tabs>
     <TabItem label="npm">
@@ -51,43 +52,105 @@ Better SSE is shipped [as a package on npm](https://www.npmjs.com/package/better
     <TabItem label="pnpm">
         <Code code={`pnpm add better-sse`} lang="shellscript" />
     </TabItem>
+    <TabItem label="Bun">
+        <Code code={`bun add better-sse`} lang="shellscript" />
+    </TabItem>
+    <TabItem label="Deno">
+        <Code code={`deno install npm:better-sse`} lang="shellscript" />
+    </TabItem>
 </Tabs>
 
 TypeScript types are included in the package distribution. No need to install from DefinitelyTyped for TypeScript users!
 
 ## Create a session
 
-*Sessions* simply represent an open connection between a client and the server. The client will first make a request to the server, and the server will open a session that it will push data to the client with.
+*Sessions* simply represent an open connection between a client and the server. The client will first make a request to the server and the server will open a session that it will push data to the client with.
 
 First import the module:
 
 <Tabs>
     <TabItem label="ESModules / TypeScript">
-        <Code code={`import { createSession } from "better-sse";`} lang="typescript" />
+        <Code code={`import { createSession } from "better-sse"`} lang="typescript" />
     </TabItem>
     <TabItem label="CommonJS">
-        <Code code={`const { createSession } = require("better-sse");`} lang="javascript" />
+        <Code code={`const { createSession } = require("better-sse")`} lang="javascript" />
     </TabItem>
 </Tabs>
 
 Then create a session when the client makes a request on the specified route (`GET /sse` in this case):
 
+<Tabs syncKey="framework">
+    <TabItem label="Express">
+        ```typescript
+        app.get("/sse", async (req, res) => {
+            const session = await createSession(req, res)
+        })
+        ```
+    </TabItem>
+    <TabItem label="Hono">
+        ```typescript
+        app.get("/sse", (c) => 
+            createResponse(c.req.raw, (session) => {
+                // ...
+            })
+        )
+        ```
+    </TabItem>
+</Tabs>
+
+Now that we have an active session we can use it to *push* an event to the client:
+
 ```typescript
-app.get("/sse", async (req, res) => {
-	const session = await createSession(req, res);
-});
+session.push("Hello world!", "ping")
 ```
 
-Now that we have an active session we can use it to push an event to the client:
+This will push the string `Hello world!` to the client as an event named `ping` (defaults to `message` if no name is given.)
 
-```typescript
-session.push("Hello world!", "ping");
-```
+<Aside title="createSession or createResponse?">
+    <details>
+        <summary>If your framework uses the Fetch API use [`createResponse`](/better-sse/reference/api/#createresponse-stateargs-constructorparameterstypeof-session-callback-session-sessionstate--void--response), otherwise use [`createSession`](/better-sse/reference/api/#createsession-stateargs-constructorparameterstypeof-session--promisesessionstate)</summary>
 
-This will push an event named `ping` (but this can be any string) with the string `Hello world!` as its associated data.
+        After creating a session we must wait for the underlying connection to be initialized before we can begin pushing events to it.
 
-<Aside>
-    If you do not specify an event name, the event name is set to `message`.
+        When using the Node [HTTP/1](https://nodejs.org/api/http.html) or [HTTP/2](https://nodejs.org/api/http2.html#compatibility-api) APIs we can flush the response headers and any other preamble data ahead of time and thus immediately begin pushing events to the session:
+
+        ```typescript
+        // Express uses the Node HTTP/1 API
+        app.get("/sse", async (req, res) => {
+            const session = await createSession(req, res)
+            session.push("Hello world!")
+        })
+        ```
+
+        When using a [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)-based framework, however, we must first return a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) object from our route handler for the session to able to connect and send data.
+
+        We can either do this manually:
+
+        ```typescript
+        // Hono uses the Fetch API
+        app.get("/sse", async (c) => {
+            const session = await createSession(c.req.raw)
+
+            session.addListener("connected", () => {
+                session.push("Hello world!")
+            })
+
+            return session.getResponse()
+        })
+        ```
+
+        Or use the shorthand [`createResponse`](/better-sse/reference/api/#createresponse-stateargs-constructorparameterstypeof-session-callback-session-sessionstate--void--response) utility function:
+
+        ```typescript
+        app.get("/sse", (c) => 
+            createResponse(c.req.raw, (session) => {
+                session.push("Hello world!")
+            })
+        )
+        ```
+
+        The previous two code snippets are equivalent.
+    </details>
 </Aside>
 
 ### Connect from the client
@@ -95,29 +158,29 @@ This will push an event named `ping` (but this can be any string) with the strin
 From your client-side code you can now connect to the server at the defined path.
 
 <Aside type="tip">
-    It is highly recommended you use an [EventSource polyfill](https://www.npmjs.com/package/eventsource) that allows for backwards compatibility with older browsers as well as giving you extra features such as request header modification and improved error handling.
+    It is **highly** recommended you use an [EventSource polyfill](/better-sse/reference/browser-compatibility/#polyfills) that allows for backwards compatibility with older browsers as well as giving you extra features such as request header modification, improved error handling and greater control over reconnection behaviour.
 </Aside>
 
-First we open a connection to the server to begin receiving events from it:
+First we open a connection to the server to begin receiving events:
 
 ```javascript
-const eventSource = new EventSource("/sse");
+const eventSource = new EventSource("/sse")
 ```
 
 Then we can attach an event listener to listen for the event our server is going to send:
 
 ```javascript
 eventSource.addEventListener("ping", (event) => {
-	console.log(`${event.type} | ${event.data}`);
-});
+	console.log(`${event.type} | ${event.data}`)
+})
 ```
 
 If you check your browser console you will now see `ping | "Hello world!"` logged to the console. Easy!
 
 <Aside>
-    Data is [serialized as JSON](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) by default. You can use `JSON.parse(data)` to get the real value of the event data.
+    Event data is serialized to JSON with [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) by default. You can use `JSON.parse(event.data)` to get its real value.
 </Aside>
 
-You can find a reference to the received event object interface under the [`MessageEvent` page on MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/message_event).
+You can find a reference to the received event object interface on the [`MessageEvent` page on MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/message_event).
 
 <LinkCard title="Examples" description="See the full code from this guide and other demo projects using Better SSE." href="https://github.com/MatthewWid/better-sse/tree/master/examples" />

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../layouts/Base.astro
 title: Better SSE
-description: Dead simple, dependency-less, spec-compliant server-sent events implementation for Node, written in TypeScript.
+description: Dead simple, dependency-less, spec-compliant server-sent events implementation written in TypeScript.
 template: splash
 hero:
     tagline: Dead simple real-time server-to-client communication without WebSockets.
@@ -28,17 +28,17 @@ import clientCode from "/src/content/snippets/home-client.ts?raw";
 	<Card title="Multi-client broadcasting" icon="rss">
 		Send events to individual clients or to many at once using broadcast channels.
 	</Card>
-	<Card title="Highly configurable" icon="setting">
-		Modify reconnection time, message serialization, data sanitization, response headers and more (with good defaults).
-	</Card>
+    <Card title="Web standards compliant" icon="puzzle">
+        Full compliance to the WHATWG SSE specification.<br />Support for modern web frameworks that use the Fetch API.
+    </Card>
 	<Card title="Event batching" icon="seti:default">
 		Batch and send multiple events in a single transmission to improve performance and lower bandwidth usage.
 	</Card>
 	<Card title="First-class TypeScript" icon="seti:typescript">
-		Fully written in TypeScript and ships with types directly.<br />Define types for state and event data.
+		Written in TypeScript and ships with types directly.<br />Define types for state and event data.
 	</Card>
-	<Card title="Pipe streams and iterables" icon="seti:pipeline">
-		Automatically pipe stream and iterable data to the client as a series of events.
+	<Card title="Highly configurable" icon="setting">
+		Modify reconnection time, message serialization, data sanitization, response headers and more (with good defaults.)
 	</Card>
 </CardGrid>
 
@@ -58,6 +58,6 @@ import clientCode from "/src/content/snippets/home-client.ts?raw";
 <CardGrid>
 	<LinkCard title="Getting started guide" description="Learn about using SSE to send events to your clients in real time" href="/better-sse/guides/getting-started" />
 	<LinkCard title="API reference" description="Read the reference documentation for all package exports" href="/better-sse/reference/api" />
-	<LinkCard title="Compare with other tools" description="Compare the features of Better SSE with other Node SSE libraries" href="/better-sse/reference/comparison" />
+	<LinkCard title="Compare with other tools" description="Compare the features of Better SSE with other SSE libraries" href="/better-sse/reference/comparison" />
 	<LinkCard title="Usage recipes" description="See examples of using Better SSE with popular HTTP frameworks" href="/better-sse/reference/recipes" />
 </CardGrid>

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -16,17 +16,29 @@ import {Aside} from "@astrojs/starlight/components";
 
 A `Session` represents an open connection between the server and the client.
 
-It emits the `connected` event after it has connected and sent all headers to the client, and the `disconnected` event after the connection has been closed.
+It emits the `connected` event after it has connected and sent the response head to the client.<br />
+It emits the `disconnected` event after the connection has been closed.
 
-Note that creating a new session will immediately send the initial status code and headers to the client. Attempting to write additional headers after you have created a new session will result in an error.
+When using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), the session is considered connected only once the `ReadableStream` contained in the body of the `Response` returned by `getResponse` has began being [consumed](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_streams).
 
-#### `new Session<State = DefaultSessionState>(req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse[, options = {}])`
+When using the [Node HTTP APIs](https://nodejs.org/api/http.html), the session will send the response status code, headers and other preamble data ahead of time, allowing the session to connect and start pushing events [immediately](https://nodejs.org/api/timers.html#setimmediatecallback-args). As such, keep in mind that attempting to write additional headers after the session has been created will result in an error being thrown.
 
-`req` is an instance of [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage) or [Http2ServerRequest](https://nodejs.org/api/http2.html#class-http2http2serverrequest).
+#### `new Session<State = DefaultSessionState>(req: IncomingMessage | Http2ServerRequest | Request, res?: ServerResponse | Http2ServerResponse | Response | SessionOptions[, options: SessionOptions])`
 
-`res` is an instance of [ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse) or [Http2ServerResponse](https://nodejs.org/api/http2.html#class-http2http2serverresponse).
+*Overloads:*
 
-`options` is an object with the following properties:
+```typescript
+new Session(IncomingMessage, ServerResponse, SessionOptions?)
+new Session(Http2ServerRequest, Http2ServerResponse, SessionOptions?)
+new Session(Request, Response, SessionOptions?)
+new Session(Request, SessionOptions?)
+```
+
+`req` is an instance of [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage), [Http2ServerRequest](https://nodejs.org/api/http2.html#class-http2http2serverrequest) or [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request).
+
+`res` is an instance of [ServerResponse](https://nodejs.org/api/http.html#http_class_http_serverresponse), [Http2ServerResponse](https://nodejs.org/api/http2.html#class-http2http2serverresponse) or [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response), respectively.
+
+`options` is a `SessionOptions` object with the following properties:
 
 |Property|Type|Default|Description|
 |-|-|-|-|
@@ -60,6 +72,25 @@ Use this object to safely store information related to the session and user.
 You may set an initial value for this property using the `state` property in the [constructor `options` object](#new-sessionstate--defaultsessionstatereq-incomingmessage--http2serverrequest-res-serverresponse--http2serverresponse-options-), allowing its type to be automatically inferred.
 
 Use [module augmentation and declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) to safely add new properties to the `DefaultSessionState` interface.
+
+#### `Session#getRequest`: `() => Request`
+
+Get a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object representing the request of the underlying connection this session manages.
+
+When using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), this will be the original `Request` object passed to the session constructor.
+
+When using the [Node HTTP APIs](https://nodejs.org/api/http.html), this will be a new `Request` object with status code and headers copied from the original request.<br />
+When the originally given request or response is closed, the abort signal attached to this `Request` will be triggered.
+
+#### `Session#getResponse`: `() => Response`
+
+Get a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) object representing the response of the underlying connection this session manages.
+
+When using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), this will be a new `Response` object with status code and headers copied from the original response if given.<br />
+Its body will be a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) that should begin being consumed for the session to consider itself connected.
+
+When using the [Node HTTP APIs](https://nodejs.org/api/http.html), this will be a new `Response` object with status code and headers copied from the original response.<br />
+Its body will be `null`, as data is instead written to the stream of the [originally given response object](https://nodejs.org/api/http.html#responsewritechunk-encoding-callback).
 
 #### `Session#push`: `(data: unknown[, eventName: string[, eventId: string]]) => this`
 
@@ -112,9 +143,53 @@ Returns a promise that resolves once all data from the event buffer has been suc
 
 ### `createSession`: `<State>(...args: ConstructorParameters<typeof Session>) => Promise<Session<State>>`
 
+*Overloads:*
+
+```typescript
+createSession(IncomingMessage, ServerResponse, SessionOptions?): Promise<Session>
+createSession(Http2ServerRequest, Http2ServerResponse, SessionOptions?): Promise<Session>
+createSession(Request, Response, SessionOptions?): Promise<Session>
+createSession(Request, SessionOptions?): Promise<Session>
+```
+
 Creates and returns a promise that resolves to an instance of a [Session](#session) once it has connected.
 
-Takes the [same arguments as the Session class constructor](#new-sessionstate--defaultsessionstatereq-incomingmessage--http2serverrequest-res-serverresponse--http2serverresponse-options-).
+Takes the [same arguments as the Session class constructor](#new-sessionstate--defaultsessionstatereq-incomingmessage--http2serverrequest--request-res-serverresponse--http2serverresponse--response--sessionoptions-options-sessionoptions).
+
+### `createResponse`: `<State>(...args: ConstructorParameters<typeof Session>, callback: (session: Session<State>) => void) => Response`
+
+*Overloads:*
+
+```typescript
+createResponse(Request, CreateResponseCallback): Response
+createResponse(Request, SessionOptions, CreateResponseCallback): Response
+createResponse(Request, Response, CreateResponseCallback): Response
+createResponse(Request, Response, SessionOptions, CreateResponseCallback): Response
+```
+
+Create a new session using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) and return its corresponding `Response` object.
+
+Takes the [same arguments as the Session class constructor](#new-sessionstate--defaultsessionstatereq-incomingmessage--http2serverrequest--request-res-serverresponse--http2serverresponse--response--sessionoptions-options-sessionoptions).
+
+The last argument should be a callback function `CreateResponseCallback` that will be invoked with the session instance once it has connected.
+
+The following two code snippets are equivalent:
+
+```typescript
+const session = await createSession(request)
+
+session.addListener("connected", () => {
+    session.push("Hello world!")
+})
+
+return session.getResponse()
+```
+
+```typescript
+return createResponse(request, (session) => {
+    session.push("Hello world!")
+})
+```
 
 ### `Channel<State, SessionState>`
 
@@ -125,9 +200,9 @@ A `Channel` is used to broadcast events to many sessions at once.
 You may use the second generic argument `SessionState` to enforce that only sessions
 with the same state type may be registered with this channel.
 
-#### `new Channel<State, SessionState>([options = {}])`
+#### `new Channel<State = DefaultChannelState, SessionState = DefaultSessionState>([options: ChannelOptions])`
 
-`options` is an object with the following properties:
+`options` is a `ChannelOptions` object with the following properties:
 
 |Property|Type|Default|Description|
 |-|-|-|-|
@@ -204,9 +279,9 @@ Takes the [same arguments as the Channel class constructor](#channelstate-sessio
 
 An `EventBuffer` allows you to write [raw spec-compliant SSE fields](https://html.spec.whatwg.org/multipage/server-sent-events.html#processField) into a text buffer that can be sent directly over the wire.
 
-#### `new EventBuffer([options = {}])`
+#### `new EventBuffer([options: EventBufferOptions])`
 
-`options` is an object with the following properties:
+`options` is an `EventBufferOptions` object with the following properties:
 
 |Property|Type|Default|Description|
 |-|-|-|-|

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -73,13 +73,15 @@ If the session has disconnected, an [`SseError`](#sseerror) will be thrown.
 
 Emits the `push` event with the given data, event name and event ID in that order.
 
-#### `Session#stream`: `(stream: Readable[, options: object]) => Promise<boolean>`
+#### `Session#stream`: `(stream: stream.Readable | ReadableStream[, options: object]) => Promise<boolean>`
 
 Pipe readable stream data to the client.
 
 Each data emission by the stream pushes a new event to the client.
 
 This uses the [`push`](#sessionpush-data-unknown-eventname-string-eventid-string--this) method under the hood.
+
+Returns a promise that resolves with `true` once the stream has been fully consumed and all data is sent to the client.
 
 |`options.`|Type|Default|Description|
 |-|-|-|-|
@@ -251,11 +253,15 @@ If no event name is given, the event name is set to `"message"`.
 
 If no event ID is given, the event ID is set to a unique string generated using a [cryptographic pseudorandom number generator](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions).
 
-#### `EventBuffer#stream`: `(stream: Readable[, options: object]) => Promise<boolean>`
+#### `EventBuffer#stream`: `(stream: stream.Readable | ReadableStream[, options: object]) => Promise<boolean>`
 
 Pipe readable stream data as a series of events into the buffer.
 
+Each data emission by the stream pushes a new event.
+
 This uses the [`push`](#eventbufferpush-data-unknown-eventname-string-eventid-string--this) method under the hood.
+
+Returns a promise that resolves with `true` once the stream has been fully consumed.
 
 |`options.`|Type|Default|Description|
 |-|-|-|-|

--- a/docs/src/content/docs/reference/browser-compatibility.mdx
+++ b/docs/src/content/docs/reference/browser-compatibility.mdx
@@ -15,7 +15,7 @@ Server-sent events is supported natively by all modern browsers.
 
 You can safely use the [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) interface without having to add any extra dependencies to your front-end code bundle.
 
-Nevertheless, should you need to support older browsers, some polyfills are listed below.
+Nevertheless, should you need to support older browsers or need additional features not supported by the native implementation, some polyfills are listed below.
 
 ## Can I Use...
 

--- a/docs/src/content/docs/reference/comparison.mdx
+++ b/docs/src/content/docs/reference/comparison.mdx
@@ -9,9 +9,9 @@ prev: false
 
 import {Aside} from "@astrojs/starlight/components";
 
-This section compares Better SSE with other server-sent events libraries for Node.
+This section compares Better SSE with other server-sent events libraries.
 
-Better SSE was designed to be the easiest and most powerful library for using server-sent events, better than all other existing solutions.
+Better SSE was designed to be the easiest and most powerful library for using server-sent events, *better* than all other existing solutions.
 
 ## Features
 

--- a/docs/src/content/docs/reference/recipes.mdx
+++ b/docs/src/content/docs/reference/recipes.mdx
@@ -11,164 +11,342 @@ Better SSE can be used with any web-server framework that uses the underlying [N
 
 Feel free to [submit a PR](https://github.com/MatthewWid/better-sse/pulls) with a minimal example for another framework!
 
-### [HTTP](https://nodejs.org/api/http.html)
+### [Node HTTP/1 API](https://nodejs.org/api/http.html)
 
 ```typescript title="server.ts"
-import { createServer } from "http";
-import { createSession } from "better-sse";
+import { createServer } from "node:http"
+import { createSession } from "better-sse"
 
 const server = createServer(async (req, res) => {
-	switch (req.url) {
+    switch (req.url) {
+        case "/sse": {
+            const session = await createSession(req, res)
+
+            session.push("Hello world!")
+
+            break
+        }
+        default: {
+            res.writeHead(404).end()
+            break
+        }
+    }
+})
+
+server.listen(8080)
+```
+
+### [Node HTTP/2 Compatibility API](https://nodejs.org/api/http2.html#compatibility-api)
+
+```typescript title="server.ts"
+import { createSecureServer } from "node:http2"
+import { createSession } from "better-sse"
+
+const server = createSecureServer({key, cert}, async (req, res) => {
+    switch (req.url) {
+        case "/sse": {
+            const session = await createSession(req, res)
+
+            session.push("Hello world!")
+
+            break
+        }
+        default: {
+            res.stream.respond({ ":status": 404 })
+            break
+        }
+    }
+})
+
+server.listen(8080)
+```
+
+### [Deno HTTP API](https://docs.deno.com/runtime/fundamentals/http_server/)
+
+```typescript title="server.ts"
+import { createResponse } from "npm:better-sse"
+
+Deno.serve({ port: 8080 }, (request) => {
+    const url = new URL(request.url)
+
+    switch (url.pathname) {
+        case "/sse": {
+            return createResponse(request, (session) => {
+                session.push("Hello world!")
+            })
+        }
+        default: {
+            return new Response("404 Not Found", {
+                status: 404,
+                headers: {
+                    "Content-Type": "text/plain",
+                },
+            })
+        }
+    }
+})
+```
+
+### [Bun HTTP API](https://bun.sh/docs/api/http)
+
+```typescript title="server.ts"
+import { createResponse } from "better-sse"
+
+Bun.serve({
+    port: 8080,
+    routes: {
+        "/sse": (req) =>
+            createResponse(
+                request,
+                // Set the keep-alive interval to below
+                // Bun's default idle timeout of ten (10) seconds
+                { keepAlive: 8000 },
+                (session) => {
+                    session.push("Hello world!")
+                }
+            ),
+    },
+    fetch() {
+        return new Response("404 Not Found", {
+            status: 404,
+            headers: {
+                "Content-Type": "text/plain",
+            },
+        })
+    },
+
+})
+```
+
+### [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+
+Using [`@mjackson/node-fetch-server`](https://www.npmjs.com/package/@mjackson/node-fetch-server) as an example of a server framework that implements the Fetch API.
+
+```typescript title="server.ts"
+import { createServer } from "node:http"
+import { createRequestListener, type FetchHandler } from "@mjackson/node-fetch-server"
+import { createResponse } from "better-sse"
+
+const handler: FetchHandler = (request) => {
+	const url = new URL(request.url)
+
+	switch (url.pathname) {
 		case "/sse": {
-			const session = await createSession(req, res);
-
-			session.push("Hello world!");
-
-			break;
+			return createResponse(request, (session) => {
+				session.push("Hello world!")
+			})
 		}
 		default: {
-			res.writeHead(404).end();
+			return new Response("404 Not Found", {
+				status: 404,
+				headers: {
+					"Content-Type": "text/plain",
+				},
+			})
 		}
 	}
-});
+}
 
-server.listen(8080);
+const server = createServer(createRequestListener(handler))
+
+server.listen(8080)
 ```
 
 ### [Express](https://expressjs.com/)
 
 ```typescript title="server.ts"
-import express from "express";
-import { createSession } from "better-sse";
+import express from "express"
+import { createSession } from "better-sse"
 
-const app = express();
+const app = express()
 
 app.get("/sse", async (req, res) => {
-    const session = await createSession(req, res);
-    session.push("Hello world!");
-});
+    const session = await createSession(req, res)
+    session.push("Hello world!")
+})
 
-app.listen(8080);
+app.listen(8080)
 ```
 
 ### [Koa](https://koajs.com/)
 
 ```typescript title="server.ts"
-import Koa from "koa";
-import Router from "@koa/router";
-import { createSession } from "better-sse";
+import Koa from "koa"
+import Router from "@koa/router"
+import { createSession } from "better-sse"
 
-const app = new Koa();
-const router = new Router();
+const app = new Koa()
+const router = new Router()
 
-router.get( "/sse", async (ctx) => {
+router.get("/sse", async (ctx) => {
     // Prevent Koa sending a response and closing the connection
-    ctx.respond = false;
+    ctx.respond = false
 
-    const session = await createSession(ctx.req, ctx.res);
+    const session = await createSession(ctx.req, ctx.res)
 
-    session.push("Hello world!");
-});
+    session.push("Hello world!")
+})
 
-app.use(router.routes());
+app.use(router.routes())
 
-app.listen(8080);
+app.listen(8080)
 ```
 
-### [Nest](https://nestjs.com/)
-
-Assuming you are using [`@nestjs/platform-express`](https://www.npmjs.com/package/@nestjs/platform-express) (the default).
+### [Hono](https://hono.dev/)
 
 ```typescript title="server.ts"
-import { Controller, Get, Req, Res } from "@nestjs/common";
-import { Request, Response } from "express";
-import { createSession } from "better-sse";
+import { Hono } from "hono"
+import { serve } from "@hono/node-server"
+import { createResponse } from "better-sse"
 
-@Controller()
-export class SseController {
-  @Get("sse")
-  async sse(@Req() req: Request, @Res() res: Response) {
-    const sse = await createSession(req, res);
+const app = new Hono()
 
-    sse.push("Hello world!");
-  }
-}
+app.get("/sse", (c) =>
+    createResponse(c.req.raw, (session) => {
+        session.push("Hello world!")
+    })
+)
+
+serve({ fetch: app.fetch, port: 8080 })
 ```
 
 ### [Next.js](https://nextjs.org/)
 
-Currently only [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) under the [Pages Router](https://nextjs.org/docs/pages) is supported.
+#### [App Router](https://nextjs.org/docs/app) ([Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers))
+
+```typescript title="app/api/sse/route.ts"
+import { createResponse } from "better-sse"
+
+export async function GET(request: Request) {
+    return createResponse(request, (session) => {
+        session.push("Hello world!")
+    })
+}
+```
+
+#### [Pages Router](https://nextjs.org/docs/pages) ([API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes))
 
 ```typescript title="pages/api/sse.ts"
-import { NextApiRequest, NextApiResponse } from "next";
-import { createSession } from "better-sse";
+import { NextApiRequest, NextApiResponse } from "next"
+import { createSession } from "better-sse"
 
 export default async function handler(
         req: NextApiRequest,
         res: NextApiResponse
 ) {
-        const session = await createSession(req, res);
+        const session = await createSession(req, res)
 
-        session.push("Hello, world!");
+        session.push("Hello world!")
 }
 ```
 
-[Issue #79](https://github.com/MatthewWid/better-sse/issues/79) tracks support for the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) and [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) objects which will enable compatibility with [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) under the [App Router](https://nextjs.org/docs/app).
+### [Nest](https://nestjs.com/)
+
+#### [`@nestjs/platform-express`](https://www.npmjs.com/package/@nestjs/platform-express)
+
+```typescript title="server.ts"
+import { Controller, Get, Req, Res } from "@nestjs/common"
+import { Request, Response } from "express"
+import { createSession } from "better-sse"
+
+@Controller()
+export class SseController {
+  @Get("sse")
+  async sse(@Req() req: Request, @Res() res: Response) {
+    const session = await createSession(req, res)
+
+    session.push("Hello world!")
+  }
+}
+```
+
+#### [`@nestjs/platform-fastify`](https://www.npmjs.com/package/@nestjs/platform-fastify)
+
+```typescript title="server.ts"
+import { Controller, Get, Req, Res } from "@nestjs/common"
+import { FastifyReply, FastifyRequest } from "fastify"
+import { createSession } from "better-sse"
+
+@Controller()
+export class SseController {
+  @Get("sse")
+  async sse(@Req() req: FastifyRequest, @Res() res: FastifyReply) {
+    const session = await createSession(req.raw, res.raw)
+
+    session.push("Hello world!")
+  }
+}
+```
 
 ### [Fastify](https://fastify.dev/)
 
 ```typescript title="server.ts"
-import Fastify from "fastify";
-import { createSession } from "better-sse";
+import Fastify from "fastify"
+import { createSession } from "better-sse"
 
-const fastify = Fastify();
+const fastify = Fastify()
 
 fastify.get("/sse", async (request, reply) => {
-        const session = await createSession(request.raw, reply.raw);
-        session.push("Hello world!");
-});
+        const session = await createSession(request.raw, reply.raw)
 
-fastify.listen({ port: 8080 });
+        session.push("Hello world!")
+})
+
+fastify.listen({ port: 8080 })
+```
+
+### [Remix](https://remix.run/)
+
+```typescript title="app/routes/sse.ts"
+import { LoaderFunction } from "@remix-run/node"
+import { createResponse } from "better-sse"
+
+export const loader: LoaderFunction = ({request}) =>
+    createResponse(request, (session) => {
+        session.push("Hello world!")
+    })
 ```
 
 ### [Adonis](https://adonisjs.com/)
 
 ```typescript title="server.ts"
-import router from "@adonisjs/core/services/router";
-import { createSession } from "better-sse";
+import router from "@adonisjs/core/services/router"
+import { createSession } from "better-sse"
 
 router.get("/sse", async ({ request, response }) => {
-  const session = await createSession(request.request, response.response);
-  session.push("Hello world!");
-});
+    const session = await createSession(request.request, response.response)
+
+    session.push("Hello world!")
+})
 ```
 
 ### [Hapi](https://hapi.dev/)
 
 ```typescript title="server.ts"
-import Hapi from "@hapi/hapi";
-import { createSession } from "better-sse";
+import Hapi from "@hapi/hapi"
+import { createSession } from "better-sse"
 
 const init = async () => {
     const server = Hapi.server({
         port: 8080,
         host: "localhost",
-    });
+    })
 
     server.route({
         method: "GET",
         path: "/sse",
         handler: async ({ raw }, { abandon }) => {
-            const session = await createSession(raw.req, raw.res);
+            const session = await createSession(raw.req, raw.res)
 
-            session.push("Hello world!");
+            session.push("Hello world!")
 
-            return abandon;
+            // Prevent Hapi from interacting further with the response stream
+            return abandon
         },
-    });
+    })
 
-    await server.start();
-};
+    await server.start()
+}
 
-init();
+init()
 ```

--- a/docs/src/content/docs/reference/recipes.mdx
+++ b/docs/src/content/docs/reference/recipes.mdx
@@ -1,13 +1,15 @@
 ---
 layout: ../../../layouts/Base.astro
 title: Usage recipes
-description: See examples of using Better SSE with various Node HTTP frameworks.
+description: See examples of using Better SSE with various HTTP frameworks.
 sidebar:
     order: 3
 next: false
 ---
 
-Better SSE can be used with any web-server framework that uses the underlying [Node HTTP module](https://nodejs.org/api/http.html). This section shows example usage with some popular HTTP frameworks.
+Better SSE works with any web-server framework that uses the [Node HTTP module](https://nodejs.org/api/http.html) or the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
+
+This section shows example usage with some popular HTTP libraries.
 
 Feel free to [submit a PR](https://github.com/MatthewWid/better-sse/pulls) with a minimal example for another framework!
 
@@ -114,7 +116,6 @@ Bun.serve({
             },
         })
     },
-
 })
 ```
 

--- a/docs/src/content/docs/reference/recipes.mdx
+++ b/docs/src/content/docs/reference/recipes.mdx
@@ -302,7 +302,7 @@ fastify.listen({ port: 8080 })
 import { LoaderFunction } from "@remix-run/node"
 import { createResponse } from "better-sse"
 
-export const loader: LoaderFunction = ({request}) =>
+export const loader: LoaderFunction = ({ request }) =>
     createResponse(request, (session) => {
         session.push("Hello world!")
     })

--- a/docs/src/content/snippets/home-client.ts
+++ b/docs/src/content/snippets/home-client.ts
@@ -2,5 +2,5 @@ const es = new EventSource("/sse")
 
 es.addEventListener("message", ({ data })) => {
 	const contents = JSON.parse(data)
-	console.log(contents)
+	console.log(contents) // Hello world!
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "better-sse",
 	"description": "Dead simple, dependency-less, spec-compliant server-sent events implementation written in TypeScript.",
-	"version": "0.14.1",
+	"version": "0.15.0",
 	"license": "MIT",
 	"author": "Matthew W. <matthew.widdi@gmail.com>",
 	"repository": "github:MatthewWid/better-sse",

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -102,11 +102,11 @@ interface SessionEvents extends EventMap {
  * It emits the `connected` event after it has connected and sent the response head to the client.
  * It emits the `disconnected` event after the connection has been closed.
  *
- * When using the Fetch API, the session is considered connected only once the ReadableStream contained in the body
- * of the Response returned by `getResponse` has began being consumed.
+ * When using the Fetch API, the session is considered connected only once the `ReadableStream` contained in the body
+ * of the `Response` returned by `getResponse` has began being consumed.
  *
- * When using the Node HTTP APIs, the session will send the response with status code, headers and other preamble data immediately,
- * allowing you to begin pushing events right after you create the session. As such, keep in mind that attempting
+ * When using the Node HTTP APIs, the session will send the response with status code, headers and other preamble data ahead of time,
+ * allowing the session to connect and start pushing events immediately. As such, keep in mind that attempting
  * to write additional headers after the session has been created will result in an error being thrown.
  *
  * @param req - The Node HTTP/1 {@link https://nodejs.org/api/http.html#http_class_http_incomingmessage | ServerResponse}, HTTP/2 {@link https://nodejs.org/api/http2.html#class-http2http2serverrequest | Http2ServerRequest} or the Fetch API {@link https://developer.mozilla.org/en-US/docs/Web/API/Request | Request} object.
@@ -350,6 +350,8 @@ class Session<State = DefaultSessionState> extends TypedEmitter<SessionEvents> {
 	 * If no event name is given, the event name is set to `"message"`.
 	 *
 	 * If no event ID is given, the event ID (and thus the `lastId` property) is set to a unique string generated using a cryptographic pseudorandom number generator.
+	 *
+	 * If the session has disconnected, an `SseError` will be thrown.
 	 *
 	 * Emits the `push` event with the given data, event name and event ID in that order.
 	 *

--- a/src/createResponse.ts
+++ b/src/createResponse.ts
@@ -8,10 +8,10 @@ import {SseError} from "./lib/SseError";
 type CreateResponseCallback<State> = (session: Session<State>) => void;
 
 /**
- * Create a new session using the Fetch API and return its Response immediately.
+ * Create a new session using the Fetch API and return its corresponding `Response` object.
  *
  * The last argument should be a callback function that will be invoked with
- * a session instance once it has connected.
+ * the session instance once it has connected.
  */
 function createResponse<State = DefaultSessionState>(
 	request: Request,
@@ -78,4 +78,5 @@ function createResponse<State = DefaultSessionState>(
 	return session.getResponse();
 }
 
+export type {CreateResponseCallback};
 export {createResponse};


### PR DESCRIPTION
This PR updates the documentation with the latest changes related to the new support for the Fetch API (#91).

It also adds [Hono](https://hono.dev/)-equivalent examples in each of the code snippets in the guides.