### PR TITLE
Publish on JSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.15.1 - 2025-05-26
+
+### Added
+
+* Added support for publishing on the [JavaScript Registry (JSR)](https://jsr.io/).
+
+### Fixed
+
+* Fixed the `stream`, `iterate` and `EventBuffer#clear` methods not having explicit return types, resulting in [slow inference](https://jsr.io/docs/about-slow-types) in certain environments.
+
 ## 0.15.0 - 2025-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # Better SSE
 
 <p>
-	<img src="https://img.shields.io/npm/v/better-sse?color=blue&style=flat-square" />
-	<img src="https://img.shields.io/npm/l/better-sse?color=green&style=flat-square" />
-	<img src="https://img.shields.io/npm/dt/better-sse?color=grey&style=flat-square" />
-	<a href="https://github.com/MatthewWid/better-sse"><img src="https://img.shields.io/github/stars/MatthewWid/better-sse?style=social" /></a>
+    <a href="https://www.npmjs.com/package/better-sse">
+        <img src="https://img.shields.io/npm/v/better-sse?color=blue&style=flat-square" alt="npm" />
+    </a>
+    <a href="https://jsr.io/@mwid/better-sse">
+        <img src="https://jsr.io/badges/@mwid/better-sse" alt="jsr" />
+    </a>
+    <a href="https://github.com/MatthewWid/better-sse/blob/master/LICENSE">
+        <img src="https://img.shields.io/npm/l/better-sse?color=green&style=flat-square" alt="MIT license" />
+    </a>
+	<img src="https://img.shields.io/npm/dt/better-sse?color=grey&style=flat-square" alt="Downloads" />
+	<a href="https://github.com/MatthewWid/better-sse">
+        <img src="https://img.shields.io/github/stars/MatthewWid/better-sse?style=social" alt="GitHub stars" />
+    </a>
 </p>
 
 A dead simple, dependency-less, spec-compliant server-sent events implementation written in TypeScript.
@@ -47,7 +56,7 @@ Read the [Getting Started](https://matthewwid.github.io/better-sse/guides/gettin
 
 # Installation
 
-Install with any package manager:
+Better SSE is published as a package on [npm](https://www.npmjs.com/package/better-sse) and the [JSR](https://jsr.io/@mwid/better-sse). You can install it with any package manager:
 
 ```sh
 npm install better-sse
@@ -66,7 +75,7 @@ bun add better-sse
 ```
 
 ```sh
-deno install npm:better-sse
+deno install jsr:@mwid/better-sse
 ```
 
 _Better SSE ships with types built in. No need to install from DefinitelyTyped for TypeScript users!_

--- a/biome.json
+++ b/biome.json
@@ -10,6 +10,7 @@
 		"ignore": [
 			"docs/src/content/snippets/*.ts",
 			"docs/src/**/*.astro",
+			"docs/.astro/**/*",
 			"examples/*/public/*.js"
 		],
 		"ignoreUnknown": false

--- a/docs/src/content/docs/guides/getting-started.mdx
+++ b/docs/src/content/docs/guides/getting-started.mdx
@@ -40,7 +40,7 @@ The technology can be used for things such as live notifications, news tickers, 
 
 ### Install
 
-Better SSE is shipped [as a package on npm](https://www.npmjs.com/package/better-sse). You can install it with any package manager.
+Better SSE is shipped as a package on [npm](https://www.npmjs.com/package/better-sse) and the [JSR](https://jsr.io/@mwid/better-sse). You can install it with any package manager.
 
 <Tabs>
     <TabItem label="npm">
@@ -56,7 +56,7 @@ Better SSE is shipped [as a package on npm](https://www.npmjs.com/package/better
         <Code code={`bun add better-sse`} lang="shellscript" />
     </TabItem>
     <TabItem label="Deno">
-        <Code code={`deno install npm:better-sse`} lang="shellscript" />
+        <Code code={`deno install jsr:@mwid/better-sse`} lang="shellscript" />
     </TabItem>
 </Tabs>
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,9 @@
+{
+	"name": "@mwid/better-sse",
+	"version": "0.15.1",
+	"exports": "./src/index.ts",
+	"publish": {
+		"include": ["LICENSE", "README.md", "CHANGELOG.md", "src/**/*.ts"],
+		"exclude": ["src/**/*.test.ts"]
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "better-sse",
 	"description": "Dead simple, dependency-less, spec-compliant server-sent events implementation written in TypeScript.",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"license": "MIT",
 	"author": "Matthew W. <matthew.widdi@gmail.com>",
 	"repository": "github:MatthewWid/better-sse",

--- a/src/EventBuffer.ts
+++ b/src/EventBuffer.ts
@@ -1,5 +1,11 @@
-import {createPushFromIterable} from "./lib/createPushFromIterable";
-import {createPushFromStream} from "./lib/createPushFromStream";
+import {
+	type PushFromIterable,
+	createPushFromIterable,
+} from "./lib/createPushFromIterable";
+import {
+	type PushFromStream,
+	createPushFromStream,
+} from "./lib/createPushFromStream";
 import {generateId} from "./lib/generateId";
 import {type SanitizerFunction, sanitize} from "./lib/sanitize";
 import {type SerializerFunction, serialize} from "./lib/serialize";
@@ -134,7 +140,7 @@ class EventBuffer {
 	push = (
 		data: unknown,
 		eventName = "message",
-		eventId = generateId()
+		eventId: string = generateId()
 	): this => {
 		this.event(eventName).id(eventId).data(data).dispatch();
 
@@ -151,9 +157,9 @@ class EventBuffer {
 	 * @param stream - Readable stream to consume data from.
 	 * @param options - Event name to use for each event created.
 	 *
-	 * @returns A promise that resolves or rejects based on the success of the stream write finishing.
+	 * @returns A promise that resolves with `true` or rejects based on the success of the stream write finishing.
 	 */
-	stream = createPushFromStream(this.push);
+	stream: PushFromStream = createPushFromStream(this.push);
 
 	/**
 	 * Iterate over an iterable and write yielded values as events into the buffer.
@@ -166,12 +172,12 @@ class EventBuffer {
 	 *
 	 * @returns A promise that resolves once all data has been successfully yielded from the iterable.
 	 */
-	iterate = createPushFromIterable(this.push);
+	iterate: PushFromIterable = createPushFromIterable(this.push);
 
 	/**
 	 * Clear the contents of the buffer.
 	 */
-	clear = () => {
+	clear = (): this => {
 		this.buffer = "";
 
 		return this;

--- a/src/createEventBuffer.ts
+++ b/src/createEventBuffer.ts
@@ -2,6 +2,6 @@ import {EventBuffer} from "./EventBuffer";
 
 const createEventBuffer = (
 	...args: ConstructorParameters<typeof EventBuffer>
-) => new EventBuffer(...args);
+): EventBuffer => new EventBuffer(...args);
 
 export {createEventBuffer};

--- a/src/lib/createPushFromIterable.ts
+++ b/src/lib/createPushFromIterable.ts
@@ -7,12 +7,14 @@ interface IterateOptions {
 	eventName?: string;
 }
 
+type PushFromIterable = (
+	iterable: Iterable<unknown> | AsyncIterable<unknown>,
+	options?: IterateOptions
+) => Promise<void>;
+
 const createPushFromIterable =
-	(push: (data: unknown, eventName: string) => void) =>
-	async <DataType = unknown>(
-		iterable: Iterable<DataType> | AsyncIterable<DataType>,
-		options: IterateOptions = {}
-	): Promise<void> => {
+	(push: (data: unknown, eventName: string) => void): PushFromIterable =>
+	async (iterable, options = {}) => {
 		const {eventName = "iteration"} = options;
 
 		for await (const data of iterable) {
@@ -20,5 +22,5 @@ const createPushFromIterable =
 		}
 	};
 
-export type {IterateOptions};
+export type {IterateOptions, PushFromIterable};
 export {createPushFromIterable};

--- a/src/lib/createPushFromStream.ts
+++ b/src/lib/createPushFromStream.ts
@@ -10,12 +10,14 @@ interface StreamOptions {
 	eventName?: string;
 }
 
+type PushFromStream = (
+	stream: NodeReadableStream | WebReadableStream,
+	options?: StreamOptions
+) => Promise<boolean>;
+
 const createPushFromStream =
-	(push: (data: unknown, eventName: string) => void) =>
-	async (
-		stream: NodeReadableStream | WebReadableStream,
-		options: StreamOptions = {}
-	): Promise<boolean> => {
+	(push: (data: unknown, eventName: string) => void): PushFromStream =>
+	async (stream, options = {}) => {
 		const {eventName = "stream"} = options;
 
 		if (stream instanceof NodeReadableStream) {
@@ -49,5 +51,5 @@ const createPushFromStream =
 		return true;
 	};
 
-export type {StreamOptions};
+export type {StreamOptions, PushFromStream};
 export {createPushFromStream};


### PR DESCRIPTION
This PR updates the package to be publishable on the [JavaScript Registry (JSR)](https://jsr.io/), as well as adding explicit return types to a number of methods in the public API to remove [slow types](https://jsr.io/docs/about-slow-types).