### PR TITLE
Add documentation on server compatibility

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -17,14 +17,33 @@ export default defineConfig({
 			sidebar: [
 				{
 					label: "Guides",
-					autogenerate: {directory: "guides"},
+					items: [
+						"guides/getting-started",
+						"guides/channels",
+						"guides/batching",
+					],
 				},
 				{
 					label: "Reference",
-					autogenerate: {directory: "reference"},
+					items: [
+						"reference/api",
+						"reference/recipes",
+						"reference/comparison",
+						{
+							label: "Compatibility",
+							items: [
+								"reference/compatibility/server",
+								"reference/compatibility/browser",
+							],
+						},
+					],
 				},
 			],
 			customCss: ["./src/styles/custom.css"],
 		}),
 	],
+	redirects: {
+		"/reference/browser-compatibility":
+			"/better-sse/reference/compatibility/browser",
+	},
 });

--- a/docs/src/content/docs/guides/batching.mdx
+++ b/docs/src/content/docs/guides/batching.mdx
@@ -2,8 +2,6 @@
 layout: ../../../layouts/Base.astro
 title: Batching with event buffers
 description: Learn how to batch and send multiple events at a time with event buffers.
-sidebar:
-    order: 3
 ---
 
 import {Tabs, TabItem, Code, Aside, Steps, LinkCard} from "@astrojs/starlight/components";

--- a/docs/src/content/docs/guides/channels.mdx
+++ b/docs/src/content/docs/guides/channels.mdx
@@ -2,10 +2,7 @@
 layout: ../../../layouts/Base.astro
 title: Broadcasting with channels
 description: Learn how to use channels which allow you to broadcast events to many clients at once.
-sidebar:
-    order: 2
 ---
-
 
 import {Tabs, TabItem, Code, Aside, Steps, LinkCard} from "@astrojs/starlight/components";
 

--- a/docs/src/content/docs/guides/getting-started.mdx
+++ b/docs/src/content/docs/guides/getting-started.mdx
@@ -2,8 +2,6 @@
 layout: ../../../layouts/Base.astro
 title: Getting started
 description: Get started using Better SSE.
-sidebar:
-    order: 1
 ---
 
 import {Tabs, TabItem, Code, Aside, Steps, LinkCard} from "@astrojs/starlight/components";

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -2,10 +2,10 @@
 layout: ../../../layouts/Base.astro
 title: API reference
 description: API reference for each Better SSE package export.
-sidebar:
-    order: 1
 tableOfContents:
     maxHeadingLevel: 4
+prev: false
+next: false
 ---
 
 import {Aside} from "@astrojs/starlight/components";

--- a/docs/src/content/docs/reference/comparison.mdx
+++ b/docs/src/content/docs/reference/comparison.mdx
@@ -2,8 +2,6 @@
 layout: ../../../layouts/Base.astro
 title: Comparison with other tools
 description: Compare the features of Better SSE with other similar Node SSE libraries.
-sidebar:
-    order: 2
 prev: false
 ---
 

--- a/docs/src/content/docs/reference/compatibility/browser.mdx
+++ b/docs/src/content/docs/reference/compatibility/browser.mdx
@@ -1,10 +1,7 @@
 ---
-layout: ../../../layouts/Base.astro
+layout: ../../../../layouts/Base.astro
 title: Browser compatibility
-description: See server-sent events browser compatibility.
-sidebar:
-    order: 4
-prev: false
+description: See browser compatibility for EventSource.
 next: false
 ---
 

--- a/docs/src/content/docs/reference/compatibility/server.mdx
+++ b/docs/src/content/docs/reference/compatibility/server.mdx
@@ -1,0 +1,39 @@
+---
+layout: ../../../../layouts/Base.astro
+title: Server compatibility
+description: See server compatibility for Better SSE.
+prev: false
+---
+
+Better SSE works with any runtime that runs JavaScript ([ES2020+](https://tc39.es/ecma262/2020/)) and supports the following APIs:
+
+* [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request), [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) and [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) from the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+* [`EventEmitter`](https://nodejs.org/api/events.html#class-eventemitter) from [`node:events`](https://nodejs.org/api/events.html)
+* [`setImmediate`](https://nodejs.org/api/timers.html#setimmediatecallback-args) from [`node:timers`](https://nodejs.org/api/timers.html)
+* [`randomUUID`](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions) (or [`randomBytes`](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) as a fallback) from [`node:crypto`](https://nodejs.org/api/crypto.html)
+* [`IncomingMessage`](https://nodejs.org/api/http.html#class-httpincomingmessage) and [`ServerResponse`](https://nodejs.org/api/http.html#class-httpserverresponse) from [`node:http`](https://nodejs.org/api/http.html)
+    * Or at least stubs their imports to `undefined` if you are instead using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+* [`Http2ServerRequest`](https://nodejs.org/api/http2.html#class-http2http2serverrequest) and [`Http2ServerResponse`](https://nodejs.org/api/http2.html#class-http2http2serverresponse) from [`node:http2`](https://nodejs.org/api/http2.html)
+    * Or at least stubs their imports to `undefined` if you are instead using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+* [`Readable`](https://nodejs.org/api/stream.html#class-streamreadable) from [`node:stream`](https://nodejs.org/api/stream.html)
+    * Or at least stubs its import to `undefined` if you are instead using [web streams](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream)
+* [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream), [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream) and [`TransformStream`](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream) from the [Web Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API)
+    * Only when using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+
+---
+
+For Node users, [version 20](https://nodejs.org/en/blog/announcements/v20-release-announce) is the minimum officially supported version.
+
+---
+
+When using the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), the provided [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and optional [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) object must be instances of [`globalThis.Request`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) and [`globalThis.Response`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis), respectively. Providing a [ponyfilled](https://ponyfill.com/) implementation will cause an [error](http://localhost:4321/better-sse/reference/api/#sseerror) to be thrown unless you also assign it to [`globalThis`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis):
+
+```typescript
+import {
+    Request as PonyfilledRequest,
+    Response as PonyfilledResponse
+} from "fetch-ponyfill"
+
+globalThis.Request = PonyfilledRequest
+globalThis.Response = PonyfilledResponse
+```

--- a/docs/src/content/docs/reference/recipes.mdx
+++ b/docs/src/content/docs/reference/recipes.mdx
@@ -2,8 +2,7 @@
 layout: ../../../layouts/Base.astro
 title: Usage recipes
 description: See examples of using Better SSE with different frameworks and runtimes.
-sidebar:
-    order: 3
+prev: false
 next: false
 ---
 


### PR DESCRIPTION
This PR adds documentation on the minimum JavaScript version, necessary supported APIs and Node.js version to be able to run Better SSE on a server.